### PR TITLE
Made item redelivery function properly

### DIFF
--- a/data/archipelago/scripts/item_utils.lua
+++ b/data/archipelago/scripts/item_utils.lua
@@ -3,6 +3,31 @@ dofile_once("data/archipelago/scripts/ap_utils.lua")
 local item_table = dofile("data/archipelago/scripts/item_mappings.lua")
 local AP = dofile("data/archipelago/scripts/constants.lua")
 
+is_redeliverable_item = {
+    [110001] = true,
+    [110002] = true,
+    [110003] = false, -- don't redeliver potions
+    [110004] = true,
+    [110005] = true,
+    [110006] = true,
+    [110007] = true,
+    [110008] = true,
+    [110009] = true,
+    [110010] = true,
+    [110011] = true,
+    [110012] = true,
+    [110013] = true,
+    [110014] = true,
+    [110015] = true,
+    [110016] = true,
+    [110017] = true,
+    [110018] = true,
+    [110019] = true,
+    [110020] = true,
+    [110021] = true, -- this is the respawn perk, whether to redeliver or not is still up for discussion
+    [110022] = true,
+}
+
 -- Traps
 local function BadTimes()
 	--Function to spawn "Bad Times" events, uses the noita streaming integration system
@@ -14,8 +39,8 @@ local function BadTimes()
 	_streaming_run_event(event.id)
 end
 
-
 function SpawnItem(item_id, traps)
+  print("item spawning shortly")
   local item = item_table[item_id]
 	if item == nil then
 		print_error("[AP] spawn_item: Item id " .. tostring(item_id) .. " does not exist!")
@@ -36,3 +61,9 @@ function SpawnItem(item_id, traps)
   end
 end
 
+function UpdateDeliveredItems(sender_location_pair)
+	delivered_items[sender_location_pair] = true
+	local f = io.open("mods/archipelago/cache/delivered_" .. ap_seed, "w")
+	f:write(JSON:encode(delivered_items))
+	f:close()
+end


### PR DESCRIPTION
-Items get sent properly in async.
-Potions and traps are not sent in async.
-All items are re-sent on new game, except for traps and potions.

I ended up removing the ShouldDeliverItem line from RECV_MSG.ReceivedItems because I couldn't figure out a good way to fit it in properly, and I don't really understand it still. But it seems to be working without it?

Added an is_redeliverable_item table to item_utils. Purpose is to just clearly define whether an item should be redelivered. There was discussion before on whether respawns should be redelivered, so feel free to change that to false. Maybe we'll make it an option later.