### PR TITLE
Item Delivery on Spawn

### DIFF
--- a/data/archipelago/scripts/ap_spawned_timer_finish.lua
+++ b/data/archipelago/scripts/ap_spawned_timer_finish.lua
@@ -1,8 +1,9 @@
 dofile_once("data/scripts/lib/utilities.lua")
 dofile_once("data/archipelago/scripts/ap_utils.lua")
 
--- just putting this here for now in case I need it, can remove the flag later if it's not useful
+
 GameAddFlagRun("ap_spawned_timer_finished")
+GlobalsSetValue("AP_FIRST_LOAD_DONE", "1")
 if GlobalsGetValue("ap_timer_first_load_done") ~= "1" then
     GlobalsSetValue("ap_timer_first_load_done", "1")
     fully_heal() -- since on spawn, you get your extra max hp from previous runs but don't get healed for it

--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -118,14 +118,14 @@ end
 
 
 -- health and money functions from the cheatgui mod
-local function get_health()
+function get_health()
 	local dm = EntityGetComponent(get_player(), "DamageModelComponent")[1]
 	return ComponentGetValue(dm, "hp"), ComponentGetValue(dm, "max_hp")
 end
 
 
 -- Note that these hp values get mulitplied by 25 by the game. Setting it to 80 means 2,000 health
-local function set_health(cur_hp, max_hp)
+function set_health(cur_hp, max_hp)
 	local damagemodels = EntityGetComponent(get_player(), "DamageModelComponent")
 	for _, damagemodel in ipairs(damagemodels or {}) do
 		ComponentSetValue(damagemodel, "max_hp", max_hp)

--- a/data/archipelago/scripts/item_mappings.lua
+++ b/data/archipelago/scripts/item_mappings.lua
@@ -1,9 +1,10 @@
 -- Keeping this slim to prevent conflicts when included in patch files
-
+-- redeliverable means it will be delivered in async
+-- newgame means it will be delivered on new game
 return {
 	[110000] = {},	-- Trap
 
-	[110001] = { items = { "data/entities/items/pickup/heart.xml" }, redeliverable = true },
+	[110001] = { items = { "data/entities/items/pickup/heart.xml" }, redeliverable = true, newgame = true },
 	[110002] = { items = { "data/entities/items/pickup/spell_refresh.xml" }, redeliverable = true },
 	[110003] = { items = { "data/entities/items/pickup/potion.xml" } },
 
@@ -12,32 +13,32 @@ return {
 	[110006] = { items = { "data/entities/items/pickup/goldnugget_200.xml" }, redeliverable = true },
 	[110007] = { items = { "data/entities/items/pickup/goldnugget_1000.xml" }, redeliverable = true },
 
-	[110008] = { items = { "data/entities/items/wand_level_01.xml", "data/entities/items/wand_unshuffle_01.xml" }, redeliverable = true },
-	[110009] = { items = { "data/entities/items/wand_level_02.xml", "data/entities/items/wand_unshuffle_02.xml" }, redeliverable = true },
-	[110010] = { items = { "data/entities/items/wand_level_03.xml", "data/entities/items/wand_unshuffle_03.xml" }, redeliverable = true },
-	[110011] = { items = { "data/entities/items/wand_level_04.xml", "data/entities/items/wand_unshuffle_04.xml" }, redeliverable = true },
-	[110012] = { items = { "data/entities/items/wand_level_05.xml", "data/entities/items/wand_unshuffle_05.xml" }, redeliverable = true },
-	[110013] = { items = { "data/entities/items/wand_level_06.xml", "data/entities/items/wand_unshuffle_06.xml" }, redeliverable = true },
+	[110008] = { items = { "data/entities/items/wand_level_01.xml", "data/entities/items/wand_unshuffle_01.xml" }, redeliverable = true, newgame = true },
+	[110009] = { items = { "data/entities/items/wand_level_02.xml", "data/entities/items/wand_unshuffle_02.xml" }, redeliverable = true, newgame = true },
+	[110010] = { items = { "data/entities/items/wand_level_03.xml", "data/entities/items/wand_unshuffle_03.xml" }, redeliverable = true, newgame = true },
+	[110011] = { items = { "data/entities/items/wand_level_04.xml", "data/entities/items/wand_unshuffle_04.xml" }, redeliverable = true, newgame = true },
+	[110012] = { items = { "data/entities/items/wand_level_05.xml", "data/entities/items/wand_unshuffle_05.xml" }, redeliverable = true, newgame = true },
+	[110013] = { items = { "data/entities/items/wand_level_06.xml", "data/entities/items/wand_unshuffle_06.xml" }, redeliverable = true, newgame = true },
 
-	[110014] = { perk = "PROTECTION_FIRE", redeliverable = true },
-	[110015] = { perk = "PROTECTION_RADIOACTIVITY", redeliverable = true },
-	[110016] = { perk = "PROTECTION_EXPLOSION", redeliverable = true },
-	[110017] = { perk = "PROTECTION_MELEE", redeliverable = true },
-	[110018] = { perk = "PROTECTION_ELECTRICITY", redeliverable = true },
-	[110019] = { perk = "EDIT_WANDS_EVERYWHERE", redeliverable = true },
-	[110020] = { perk = "REMOVE_FOG_OF_WAR", redeliverable = true },
-	[110021] = { perk = "RESPAWN" }, -- extra life
+	[110014] = { perk = "PROTECTION_FIRE", redeliverable = true, newgame = true },
+	[110015] = { perk = "PROTECTION_RADIOACTIVITY", redeliverable = true, newgame = true },
+	[110016] = { perk = "PROTECTION_EXPLOSION", redeliverable = true, newgame = true },
+	[110017] = { perk = "PROTECTION_MELEE", redeliverable = true, newgame = true },
+	[110018] = { perk = "PROTECTION_ELECTRICITY", redeliverable = true, newgame = true },
+	[110019] = { perk = "EDIT_WANDS_EVERYWHERE", redeliverable = true, newgame = true },
+	[110020] = { perk = "REMOVE_FOG_OF_WAR", redeliverable = true, newgame = true },
+	[110021] = { perk = "RESPAWN", redeliverable = true }, -- extra life
 
-	[110022] = { items = { "mods/archipelago/data/archipelago/entities/items/orbs/ap_orb_randomizer_spawned.xml" }, redeliverable = true },
+	[110022] = { items = { "mods/archipelago/data/archipelago/entities/items/orbs/ap_orb_randomizer_spawned.xml" }, redeliverable = true, newgame = true },
 
 	[110023] = { items = { "data/entities/items/pickup/potion_random_material.xml" } }, -- random potion
 	[110024] = { items = { "data/entities/items/pickup/potion_secret.xml" } }, -- secret potion
 	[110025] = { items = { "data/entities/items/pickup/physics_die.xml" } }, -- chaos die
 	[110026] = { items = { "data/entities/items/pickup/physics_greed_die.xml" } }, -- greed die
-	[110027] = { items = { "data/entities/items/pickup/safe_haven.xml" }, redeliverable = true }, -- kammi
-	[110028] = { items = { "data/entities/items/pickup/gourd.xml" }, redeliverable = true }, -- gourd
-	[110029] = { items = { "data/entities/items/pickup/beamstone.xml" }, redeliverable = true }, -- sadekivi
-	[110030] = { items = { "data/entities/items/pickup/broken_wand.xml" }, redeliverable = true }, -- broken wand
-	[110031] = { items = { "data/entities/items/pickup/powder_stash.xml" }, redeliverable = true }, -- powder pouch
-	[110032] = { perk = "MAP", redeliverable = true }, -- spatial awareness perk, for runs including toveri boss
+	[110027] = { items = { "data/entities/items/pickup/safe_haven.xml" }, redeliverable = true, newgame = true }, -- kammi
+	[110028] = { items = { "data/entities/items/pickup/gourd.xml" }, redeliverable = true, newgame = true }, -- gourd
+	[110029] = { items = { "data/entities/items/pickup/beamstone.xml" }, redeliverable = true, newgame = true }, -- sadekivi
+	[110030] = { items = { "data/entities/items/pickup/broken_wand.xml" }, redeliverable = true, newgame = true }, -- broken wand
+	[110031] = { items = { "data/entities/items/pickup/powder_stash.xml" }, redeliverable = true, newgame = true }, -- powder pouch
+	[110032] = { perk = "MAP", redeliverable = true, newgame = true }, -- spatial awareness perk, for runs including toveri boss
 }

--- a/data/archipelago/scripts/item_mappings.lua
+++ b/data/archipelago/scripts/item_mappings.lua
@@ -13,12 +13,12 @@ return {
 	[110006] = { items = { "data/entities/items/pickup/goldnugget_200.xml" }, redeliverable = true },
 	[110007] = { items = { "data/entities/items/pickup/goldnugget_1000.xml" }, redeliverable = true },
 
-	[110008] = { items = { "data/entities/items/wand_level_01.xml", "data/entities/items/wand_unshuffle_01.xml" }, redeliverable = true, newgame = true },
-	[110009] = { items = { "data/entities/items/wand_level_02.xml", "data/entities/items/wand_unshuffle_02.xml" }, redeliverable = true, newgame = true },
-	[110010] = { items = { "data/entities/items/wand_level_03.xml", "data/entities/items/wand_unshuffle_03.xml" }, redeliverable = true, newgame = true },
-	[110011] = { items = { "data/entities/items/wand_level_04.xml", "data/entities/items/wand_unshuffle_04.xml" }, redeliverable = true, newgame = true },
-	[110012] = { items = { "data/entities/items/wand_level_05.xml", "data/entities/items/wand_unshuffle_05.xml" }, redeliverable = true, newgame = true },
-	[110013] = { items = { "data/entities/items/wand_level_06.xml", "data/entities/items/wand_unshuffle_06.xml" }, redeliverable = true, newgame = true },
+	[110008] = { items = { "data/entities/items/wand_level_01.xml", "data/entities/items/wand_unshuffle_01.xml" }, redeliverable = true, newgame = true, wand = true },
+	[110009] = { items = { "data/entities/items/wand_level_02.xml", "data/entities/items/wand_unshuffle_02.xml" }, redeliverable = true, newgame = true, wand = true },
+	[110010] = { items = { "data/entities/items/wand_level_03.xml", "data/entities/items/wand_unshuffle_03.xml" }, redeliverable = true, newgame = true, wand = true },
+	[110011] = { items = { "data/entities/items/wand_level_04.xml", "data/entities/items/wand_unshuffle_04.xml" }, redeliverable = true, newgame = true, wand = true },
+	[110012] = { items = { "data/entities/items/wand_level_05.xml", "data/entities/items/wand_unshuffle_05.xml" }, redeliverable = true, newgame = true, wand = true },
+	[110013] = { items = { "data/entities/items/wand_level_06.xml", "data/entities/items/wand_unshuffle_06.xml" }, redeliverable = true, newgame = true, wand = true },
 
 	[110014] = { perk = "PROTECTION_FIRE", redeliverable = true, newgame = true },
 	[110015] = { perk = "PROTECTION_RADIOACTIVITY", redeliverable = true, newgame = true },

--- a/data/archipelago/scripts/item_utils.lua
+++ b/data/archipelago/scripts/item_utils.lua
@@ -46,6 +46,23 @@ function SpawnItem(item_id, traps)
 	end
 end
 
+
+function NGSpawnItems(item_id_table)
+	local xoff = -50
+	for item, quantity in pairs(item_id_table) do
+		for _ = 1, quantity do
+			if item_table[item].perk ~= nil then
+				give_perk(item_table[item].perk)
+			elseif #item_table[item].items > 0 then
+				local item_to_spawn = item_table[item].items[Random(1, #item_table[item].items)]
+				EntityLoadAtPlayer(item_to_spawn, xoff, -30)
+				xoff = xoff + 20
+			end
+		end
+	end
+end
+
+
 local LocationFlags = {
 	[110501] = "orb_0",
 	[110502] = "orb_1",

--- a/data/archipelago/scripts/item_utils.lua
+++ b/data/archipelago/scripts/item_utils.lua
@@ -48,15 +48,13 @@ end
 
 
 function NGSpawnItems(item_list)
-	local xoff = -50
-	local yoff = -30 -- negative means it spawns above you
+	local itemx = 595
+	local itemy = -90
+	local wandx = 600
+	local wandy = -120
 	local item_count = 0
 	for _, v in pairs(item_list) do
 		item_count = item_count + v
-	end
-	if item_count == 1 then
-		xoff = 0
-		yoff = 0
 	end
 	-- check how many hearts are on the list, increase your health based on them, then remove them from the list
 	if item_list[110001] ~= nil then
@@ -66,15 +64,46 @@ function NGSpawnItems(item_list)
 		set_health(cur_hp, max_hp)
 		item_list[110001] = nil
 	end
+
+	-- spawn the wands in an array inside the cave
 	for item, quantity in pairs(item_list) do
-		for _ = 1, quantity do
-			if item_table[item].perk ~= nil then
-				give_perk(item_table[item].perk)
-			elseif #item_table[item].items > 0 then
+		print(item, quantity)
+		if item_table[item].wand ~= nil then
+			for _ = 1, quantity do
 				local item_to_spawn = item_table[item].items[Random(1, #item_table[item].items)]
-				EntityLoadAtPlayer(item_to_spawn, xoff, yoff)
-				xoff = xoff + 20
+				EntityLoad(item_to_spawn, wandx, wandy)
+				wandx = wandx + 20
+				if wandx >= 800 then
+					wandx = 600
+					wandy = wandy -10
+				end
 			end
+			item_list[item] = nil
+			-- give the player their perks
+		elseif item_table[item].perk ~= nil then
+			for _ = 1, quantity do
+				give_perk(item_table[item].perk)
+			end
+			item_table[item] = nil
+		else
+			-- spawn the rest of the items on the cave floor
+			for _ = 1, quantity do
+				if #item_table[item].items > 0 then
+					print("spawning" .. item .. "at" .. itemx .. itemy)
+					local item_to_spawn = item_table[item].items[Random(1, #item_table[item].items)]
+					EntityLoad(item_to_spawn, itemx, itemy)
+					itemx = itemx + 15
+					-- skip the minecart
+					if itemx > 662 and itemx < 692 then
+						itemx = itemx + 30
+					end
+					-- loop back around, but slightly offset
+					if itemx >= 800 then
+						itemx = itemx - 205
+					end
+				end
+			end
+			item_list[item] = nil
 		end
 	end
 end

--- a/data/archipelago/scripts/item_utils.lua
+++ b/data/archipelago/scripts/item_utils.lua
@@ -49,13 +49,18 @@ end
 
 function NGSpawnItems(item_id_table)
 	local xoff = -50
+	local yoff = -30 -- negative means it spawns above you
+	if #item_id_table == 1 then
+		xoff = 0
+		yoff = 0
+	end
 	for item, quantity in pairs(item_id_table) do
 		for _ = 1, quantity do
 			if item_table[item].perk ~= nil then
 				give_perk(item_table[item].perk)
 			elseif #item_table[item].items > 0 then
 				local item_to_spawn = item_table[item].items[Random(1, #item_table[item].items)]
-				EntityLoadAtPlayer(item_to_spawn, xoff, -30)
+				EntityLoadAtPlayer(item_to_spawn, xoff, yoff)
 				xoff = xoff + 20
 			end
 		end

--- a/data/archipelago/scripts/item_utils.lua
+++ b/data/archipelago/scripts/item_utils.lua
@@ -47,14 +47,26 @@ function SpawnItem(item_id, traps)
 end
 
 
-function NGSpawnItems(item_id_table)
+function NGSpawnItems(item_list)
 	local xoff = -50
 	local yoff = -30 -- negative means it spawns above you
-	if #item_id_table == 1 then
+	local item_count = 0
+	for _, v in pairs(item_list) do
+		item_count = item_count + v
+	end
+	if item_count == 1 then
 		xoff = 0
 		yoff = 0
 	end
-	for item, quantity in pairs(item_id_table) do
+	-- check how many hearts are on the list, increase your health based on them, then remove them from the list
+	if item_list[110001] ~= nil then
+		local cur_hp, max_hp = get_health()
+		cur_hp = cur_hp + item_list[110001]
+		max_hp = max_hp + item_list[110001]
+		set_health(cur_hp, max_hp)
+		item_list[110001] = nil
+	end
+	for item, quantity in pairs(item_list) do
 		for _ = 1, quantity do
 			if item_table[item].perk ~= nil then
 				give_perk(item_table[item].perk)

--- a/init.lua
+++ b/init.lua
@@ -317,10 +317,13 @@ function RECV_MSG.ReceivedItems(msg)
 	else
 		-- we're starting a new game
 		local ng_items = {}
+		local sender = -1
+		local table_length = 0
 		for _, item in pairs(msg["items"]) do
 			index = index + 1
+			table_length = table_length + 1
 			local item_id = item["item"]
-			local sender = item["player"]
+			sender = item["player"]
 			local location_id = item["location"]
 			local cache_key = Cache.make_key(sender, location_id)
 			Cache.ItemDelivery:set(cache_key)
@@ -333,7 +336,11 @@ function RECV_MSG.ReceivedItems(msg)
 				end
 			end
 		end
-		NGSpawnItems(ng_items)
+		if sender == current_player_slot and index == 0 and table_length == 1 then
+			print("player found their own item as their first item")
+		else
+			NGSpawnItems(ng_items)
+		end
 		GlobalsSetValue(LOAD_KEY, "1")
 	end
 end

--- a/init.lua
+++ b/init.lua
@@ -327,8 +327,8 @@ function RECV_MSG.ReceivedItems(msg)
 			local location_id = item["location"]
 			local cache_key = Cache.make_key(sender, location_id)
 			Cache.ItemDelivery:set(cache_key)
-
-			if item_table[item_id].redeliverable then
+			-- count up the items that should be delivered on new game
+			if item_table[item_id].newgame then
 				if ng_items[item_id] == nil then
 					ng_items[item_id] = 1
 				else
@@ -341,7 +341,6 @@ function RECV_MSG.ReceivedItems(msg)
 		else
 			NGSpawnItems(ng_items)
 		end
-		GlobalsSetValue(LOAD_KEY, "1")
 	end
 end
 


### PR DESCRIPTION
Made it so items spawn around you on new game. This isn't the final design intent, as currently there are issues, such as gourds just falling to the ground and activating, and also this is sloppy. Ideally the end result will be a box or something the player can interact with, or bins that fill up with items. Something like that.

Also added another category to item_mapping, newgame, which defines which items should be re-sent on new game.