### PR TITLE
Crash fix on pedestal item error

### DIFF
--- a/data/archipelago/scripts/ap_pedestal_replacer.lua
+++ b/data/archipelago/scripts/ap_pedestal_replacer.lua
@@ -34,10 +34,13 @@ local function PedestalReplacer()
                                 y = y - 8
                                 x = x + 0.5
                             end
+                        -- wands
                         elseif item_id >= 110008 and item_id <= 110013 then
                             y = y + 0.5
+                        -- potions or powder stash
                         elseif contains_element({110003, 110023, 110024, 110031}, item_id) and replaced_pedestal == "wand" then
                             x = x + 1.5
+                        -- kammi
                         elseif item_id == 110027 and replaced_pedestal == "potion" then
                             x = x + 0.5
                         end

--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -214,6 +214,7 @@ function create_ap_entity_from_flags(location, x, y)
   	local item_description = "$ap_shopdescription_junk"
 	if flags == nil then
 		print("flags == nil")
+		item_description = "problem with item in create_ap_entity_from_flags"
 	elseif bit.band(flags, AP.ITEM_FLAG_USEFUL) ~= 0 then
 	    item_filename = "ap_useful_shopitem.xml"
 	    item_description = "$ap_shopdescription_useful"
@@ -248,7 +249,7 @@ function create_our_item_entity(item, x, y)
 		end
 		return entity_id
   	else
-    	Log.Error("Failed to load our own item!")
+    	Log.Error("Failed to load our own item at x = " .. x .. ", y = " .. y)
   	end
 end
 
@@ -256,7 +257,7 @@ end
 -- Spawns in an AP item (our own entity to represent items that don't exist in this game)
 function create_foreign_item_entity(location, x, y)
   local entity_id, description = create_ap_entity_from_flags(location, x, y)
-  local name = location.item_name
+  local name = location.item_name or "problem in create_foreign_item_entity"
 
   -- Change item name
   change_entity_ingame_name(entity_id, name, description)


### PR DESCRIPTION
Gave pedestal items name and description in the event that they don't properly get them (in the event that your datapackage isn't there, or if it wasn't there fast enough). Going to follow this up with something to make the pedestal items or hidden chests spawn normally in the event the datapackage didn't show up, it's just good to have a back up plan.