### PR TITLE
Missing Log reference

### DIFF
--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -1,6 +1,7 @@
 dofile_once("data/scripts/lib/utilities.lua")
 dofile_once("data/scripts/perks/perk.lua")
 local AP = dofile("data/archipelago/scripts/constants.lua")
+local Log = dofile("data/archipelago/scripts/logger.lua")
 
 
 function contains_element(tbl, elem)


### PR DESCRIPTION
Added in a missing Log dofile. Was flooding the log with errors when starting up the game while one of the cache files was open.