### PR TITLE
Make it so if multiple items spawn, they don't spawn with the same seed

### DIFF
--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -78,10 +78,14 @@ end
 
 
 -- Uses the player's position to initialize the random seed
-function SeedRandom()
+function SeedRandom(a, b)
+	if a == nil or b == nil then
+		a = 0
+		b = 0
+	end
 	for _, p in ipairs(get_players()) do
 		local x, y = EntityGetTransform(p)
-		SetRandomSeed(x, y)
+		SetRandomSeed(x + a, y + b)
 	end
 end
 

--- a/data/archipelago/scripts/item_utils.lua
+++ b/data/archipelago/scripts/item_utils.lua
@@ -38,12 +38,15 @@ function SpawnItem(item_id, traps)
 		Log.Error("[AP] spawn_item: Item id " .. tostring(item_id) .. " does not exist!")
 		return
 	end
-
-	SeedRandom()
+	-- setting the random seed using arbitrary offsets that get modified on each spawn
+	local rand_x = GlobalsGetValue("ap_random_hax")
+	local rand_y = rand_x * 2
+	SeedRandom(rand_x, rand_y)
 
 	if item_id == AP.TRAP_ID then
 		if not traps then return end
 		BadTimes()
+		GlobalsSetValue("ap_random_hax", rand_x + 2)
 		Log.Info("Badtimes")
 	elseif item.perk ~= nil then
 		give_perk(item.perk)
@@ -52,9 +55,11 @@ function SpawnItem(item_id, traps)
 		add_money(item.gold_amount)
 	elseif item.potion ~= nil then
 		spawn_potion(item.items[1])
+		GlobalsSetValue("ap_random_hax", rand_x + 2)
 	elseif #item.items > 0 then
 		local item_to_spawn = item.items[Random(1, #item.items)]
 		EntityLoadAtPlayer(item_to_spawn, random_offset())
+		GlobalsSetValue("ap_random_hax", rand_x + 2)
 		Log.Info("Item spawned" .. item_to_spawn)
 	else
 		Log.Error("[AP] Item " .. tostring(item_id) .. " not properly configured")

--- a/data/archipelago/scripts/patches/ap_orb_init_random.lua
+++ b/data/archipelago/scripts/patches/ap_orb_init_random.lua
@@ -19,8 +19,10 @@ local function APOrbInitRandom()
 		EntityRemoveComponent(entity_id, comp_id)
 	end
 
-	-- todo: after the ap client update, put together a check for whether the orb has been checked already
-	local location = Globals.LocationScouts:get_key(orb_id + Constants.FIRST_ORB_LOCATION_ID)
+	local location_id = orb_id + Constants.FIRST_ORB_LOCATION_ID
+	if not Globals.MissingLocationsSet:has_key(location_id) then return end
+
+	local location = Globals.LocationScouts:get_key(location_id)
 	local flags = location.item_flags
 	local orb_image = "ap_logo_orb"
 	local check_type_icon = "filler_icon"

--- a/data/archipelago/scripts/patches/ap_orb_pickup_random.lua
+++ b/data/archipelago/scripts/patches/ap_orb_pickup_random.lua
@@ -11,7 +11,9 @@ function item_pickup( entity_item, entity_who_picked, item_name )
 	local entity_id = GetUpdatedEntityID()
 
 	local orb_id = getInternalVariableValue(entity_id, "OriginalID", "value_int")
-	GameAddFlagRun("ap_orb_" .. orb_id)
+	if orb_id ~= nil then
+		GameAddFlagRun("ap_orb_" .. orb_id)
+	end
 
 	EntityLoad( "data/entities/items/pickup/heart.xml", pos_x, pos_y )
 

--- a/init.lua
+++ b/init.lua
@@ -689,4 +689,5 @@ end
 
 function OnPlayerSpawned()
 	is_player_spawned = true
+	GlobalsSetValue("ap_random_hax", 23)
 end


### PR DESCRIPTION
Before, even with the offset, the flaw was that there was still the same seed for the random offset, so it just offset them all to the same exact spot. Now we check a global value, spawn the item/trap, then increment it. I have tested and it does appear to be working.

And while the random spawn position offset is no longer required, I think it looks visually better with it.