### PR TITLE
Removed orb message for natural-spawn orbs

### DIFF
--- a/data/archipelago/scripts/patches/ap_orb_init_random.lua
+++ b/data/archipelago/scripts/patches/ap_orb_init_random.lua
@@ -50,12 +50,14 @@ local function APOrbInitRandom()
 			image_file = "data/archipelago/entities/items/icons/" .. orb_image .. ".png",
 			offset_x = 7,
 			offset_y = 20,
+			z_index = 0.8,
 		})
 
 		EntityAddComponent2(entity_id, "SpriteComponent", {
 			image_file = "data/archipelago/entities/items/icons/" .. check_type_icon .. ".png",
 			offset_x = 0,
 			offset_y = 10,
+			z_index = 0.7,
 		})
 	end
 end

--- a/data/archipelago/scripts/patches/ap_orb_pickup_random.lua
+++ b/data/archipelago/scripts/patches/ap_orb_pickup_random.lua
@@ -6,8 +6,6 @@ dofile_once("data/archipelago/scripts/ap_utils.lua")
 function item_pickup( entity_item, entity_who_picked, item_name )
 	local pos_x, pos_y = EntityGetTransform( entity_item )
 
-	local message_title = "$itempickup_orb_discovered"
-	local message_desc = "$itempickupdesc_orb_discovered"
 	local entity_id = GetUpdatedEntityID()
 
 	local orb_id = getInternalVariableValue(entity_id, "OriginalID", "value_int")
@@ -16,14 +14,6 @@ function item_pickup( entity_item, entity_who_picked, item_name )
 	end
 
 	EntityLoad( "data/entities/items/pickup/heart.xml", pos_x, pos_y )
-
-	if( GameHasFlagRun( "boss_centipede_is_dead" ) == false ) then
-		local x,y = EntityGetTransform( entity_who_picked )
-		local child_id = EntityLoad( "data/entities/misc/orb_boss_scream.xml", x, y )
-		EntityAddChild( entity_who_picked, child_id )
-	end
-
-	GamePrintImportant( message_title, message_desc )
 
 	shoot_projectile( entity_who_picked, "data/entities/particles/image_emitters/orb_effect.xml", pos_x, pos_y, 0, 0 )
 	EntityKill( entity_item )


### PR DESCRIPTION
This is to fix an issue where if you pick up a natural-spawn orb that has a check, it won't actually show the check message because of the orb's message and the heart pickup message. And it doesn't increase your orb count anyway, so the message doesn't matter much.

Also got rid of the kolmi shout since it doesn't increase kolmi's health either.