### PR TITLE
Potions are safer, also better support for ap console /send

### DIFF
--- a/data/archipelago/materials.xml
+++ b/data/archipelago/materials.xml
@@ -1,6 +1,23 @@
 <Materials>
 
   <CellData
+    name="ap_gorilla_glass"
+    ui_name="$mat_potion_glass_box2d"
+    tags="[box2d],[matter_eater_ignore_list],[sunbaby_ignore_list],[indestructible]"
+    wang_color="ff223443"
+    durability="18"
+    audio_physics_material_solid="glass"
+    platform_type="1"
+    cell_type="solid"
+    >
+    <Graphics
+      normal_mapped="1"
+      texture_file="data/materials_gfx/crystal.png"
+      color="ff5787E7" >
+    </Graphics>
+  </CellData>
+
+  <CellData
     name="ap_chest"
     ui_name="$mat_ap_chest"
     tags="[box2d],[matter_eater_ignore_list],[sunbaby_ignore_list],[indestructible]"

--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -48,9 +48,13 @@ function spawn_potion(potion, x, y)
 	end
 
 	local potion_entity = EntityLoad(potion, random_offset(x, y))
-	local physics_damage_comp = EntityGetFirstComponentIncludingDisabled(potion_entity, "PhysicsBodyCollisionDamageComponent")
-	if physics_damage_comp ~= nil then
-		ComponentSetValue2(physics_damage_comp, "damage_multiplier", 0)
+	local damage_model_comp = EntityGetFirstComponentIncludingDisabled(potion_entity, "DamageModelComponent")
+	local explode_comp = EntityGetFirstComponentIncludingDisabled(potion_entity, "ExplodeOnDamageComponent")
+	if damage_model_comp ~= nil then
+		ComponentSetValue2(damage_model_comp, "invincibility_frames", 90)
+	end
+	if explode_comp ~= nil then
+		ComponentSetValue2(explode_comp, "physics_body_destruction_required", 1)
 	end
 
 	EntityAddComponent(potion_entity, "LuaComponent", {

--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -49,13 +49,10 @@ function spawn_potion(potion, x, y)
 
 	local potion_entity = EntityLoad(potion, random_offset(x, y))
 	local damage_model_comp = EntityGetFirstComponentIncludingDisabled(potion_entity, "DamageModelComponent")
-	local explode_comp = EntityGetFirstComponentIncludingDisabled(potion_entity, "ExplodeOnDamageComponent")
 	if damage_model_comp ~= nil then
 		ComponentSetValue2(damage_model_comp, "invincibility_frames", 90)
 	end
-	if explode_comp ~= nil then
-		ComponentSetValue2(explode_comp, "physics_body_destruction_required", 1)
-	end
+	EntityConvertToMaterial(potion_entity, "ap_gorilla_glass")
 
 	EntityAddComponent(potion_entity, "LuaComponent", {
 		script_source_file="data/archipelago/scripts/items/potion_saver_remover.lua",

--- a/data/archipelago/scripts/items/potion_saver_remover.lua
+++ b/data/archipelago/scripts/items/potion_saver_remover.lua
@@ -1,10 +1,12 @@
 local entity_id = GetUpdatedEntityID()
 local comp_id = GetUpdatedComponentID()
-local physics_damage_comp = EntityGetFirstComponentIncludingDisabled(entity_id, "PhysicsBodyCollisionDamageComponent")
-ComponentSetValue2(physics_damage_comp, "damage_multiplier", 0.017)
+local explode_comp = EntityGetFirstComponentIncludingDisabled(entity_id, "ExplodeOnDamageComponent")
+ComponentSetValue2(explode_comp, "physics_body_destruction_required", 0.51)
 EntityRemoveComponent(entity_id, comp_id)
 
 function item_pickup(potion_id, entity_pickupper, item_name)
-    local potion_physics_damage_comp = EntityGetFirstComponentIncludingDisabled(potion_id, "PhysicsBodyCollisionDamageComponent")
-    ComponentSetValue2(potion_physics_damage_comp, "damage_multiplier", 0.017)
+    local potion_comp_id = GetUpdatedComponentID()
+    local potion_explode_comp = EntityGetFirstComponentIncludingDisabled(potion_id, "ExplodeOnDamageComponent")
+    ComponentSetValue2(potion_explode_comp, "physics_body_destruction_required", 0.51)
+    EntityRemoveComponent(potion_id, potion_comp_id)
 end

--- a/data/archipelago/scripts/items/potion_saver_remover.lua
+++ b/data/archipelago/scripts/items/potion_saver_remover.lua
@@ -1,12 +1,10 @@
 local entity_id = GetUpdatedEntityID()
 local comp_id = GetUpdatedComponentID()
-local explode_comp = EntityGetFirstComponentIncludingDisabled(entity_id, "ExplodeOnDamageComponent")
-ComponentSetValue2(explode_comp, "physics_body_destruction_required", 0.51)
+EntityConvertToMaterial(entity_id, "potion_glass_box2d")
 EntityRemoveComponent(entity_id, comp_id)
 
 function item_pickup(potion_id, entity_pickupper, item_name)
     local potion_comp_id = GetUpdatedComponentID()
-    local potion_explode_comp = EntityGetFirstComponentIncludingDisabled(potion_id, "ExplodeOnDamageComponent")
-    ComponentSetValue2(potion_explode_comp, "physics_body_destruction_required", 0.51)
+    EntityConvertToMaterial(potion_id, "potion_glass_box2d")
     EntityRemoveComponent(potion_id, potion_comp_id)
 end

--- a/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
+++ b/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
@@ -55,6 +55,24 @@ local function APPedestalReplacer()
 					_tags="archipelago",
 					script_item_picked_up="data/archipelago/scripts/items/ap_pedestal_processed.lua",
 				})
+				local particle_comp = EntityAddComponent(ap_pedestal_id, "SpriteParticleEmitterComponent", {
+					sprite_file="data/archipelago/entities/items/icon-useful.png",
+					lifetime=6,
+					additive=true,
+					emissive=true,
+					velocity_slowdown=5,
+					velocity_always_away_from_center=true,
+					count_min=1,
+					count_max=1,
+					emission_interval_min_frames=60,
+					emission_interval_max_frames=90,
+				})
+				-- EntityAddComponent can't set multi-value types
+				ComponentSetValue2(particle_comp, "color", 1, 1, 1, .4)
+				ComponentSetValue2(particle_comp, "color_change", 0, 0, 0, -.2)
+				ComponentSetValue2(particle_comp, "scale", 0.15, 0.15)
+				ComponentSetValue2(particle_comp, "scale_velocity", 0.2, 0.2)
+				ComponentSetValue2(particle_comp, "randomize_rotation", 0, 50)
 				return true
 			end
 		end

--- a/init.lua
+++ b/init.lua
@@ -347,7 +347,11 @@ function RECV_MSG.ReceivedItems(msg)
 			local location_id = item["location"]
 
 			local cache_key = Cache.make_key(sender, location_id)
-			if not Cache.ItemDelivery:is_set(cache_key) then
+			-- items given through the server console have a location ID of -1
+			if location_id == -1 and recv_index ~= 0 then
+				SpawnItem(item_id, true)
+				index = index + 1
+			elseif not Cache.ItemDelivery:is_set(cache_key) then
 				Cache.ItemDelivery:set(cache_key)
 
 				if not GameHasFlagRun("ap_spawn_kill_saver") and item_table[item_id].redeliverable then
@@ -462,7 +466,8 @@ function RECV_MSG.PrintJSON(msg)
 			GamePrint(msg_str)
 		end
 	else
-		Log.Warn("Unsupported PrintJSON type " .. msg["type"])
+		local msg_type = msg["type"] or "none"
+		Log.Warn("Unsupported PrintJSON type " .. msg_type)
 		if msg["data"] ~= nil then
 			local msg_str = ParseJSONParts(msg["data"])
 			GamePrint(msg_str)


### PR DESCRIPTION
So there's an iframe line in the damage model component.
It doesn't prevent physics damage, and the potion doesn't update it's material component until it has been picked up and dropped again after the material component is changed, so it can still be destroyed by physics-modifying attacks, but it's less likely to be destroyed since you now have to destroy the entire model during those first 90 frames of life instead of just 51% of it.

Also, you can send items directly using the server console. When you do so, it sends with a location ID of -1. I've added in some support for this since, without the additional support, it only sends the first time you run the command. Any other time, it sees that you've already sent an item from location -1, so it doesn't send it again since it thinks it's a duplicate send.