### PR TITLE
Item radar works on pedestal items now

### DIFF
--- a/data/archipelago/entities/items/base_ap_shopitem.xml
+++ b/data/archipelago/entities/items/base_ap_shopitem.xml
@@ -1,4 +1,4 @@
-<Entity tags="teleportable_NOT,item">
+<Entity tags="teleportable_NOT,item,item_pickup">
   <!-- I think we need this so the item can drop (stealing from the shop) -->
   <!-- https://noita.wiki.gg/wiki/Documentation:_VelocityComponent -->
   <VelocityComponent/>

--- a/data/archipelago/entities/items/pickup/ap_chest_random.xml
+++ b/data/archipelago/entities/items/pickup/ap_chest_random.xml
@@ -1,4 +1,4 @@
-<Entity tags="teleportable_NOT,item_physics,chest,item_pickup,indestructible,ap_chest">
+<Entity tags="teleportable_NOT,item_physics,chest,item_pickup,indestructible,ap_chest,forgeable">
     <UIInfoComponent
             name="$ap_chest_random"
     >

--- a/data/archipelago/materials.xml
+++ b/data/archipelago/materials.xml
@@ -4,7 +4,7 @@
     name="ap_gorilla_glass"
     ui_name="$mat_potion_glass_box2d"
     tags="[box2d],[matter_eater_ignore_list],[sunbaby_ignore_list],[indestructible]"
-    wang_color="ff223443"
+    wang_color="ff223447"
     durability="18"
     audio_physics_material_solid="glass"
     platform_type="1"

--- a/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
+++ b/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
@@ -46,33 +46,32 @@ local function APPedestalReplacer()
 				local ap_pedestal_id = nil
 				if location.is_our_item and item and item_id ~= AP.TRAP_ID then
 					ap_pedestal_id = create_our_item_entity(item, x, y)
+					addNewInternalVariable(ap_pedestal_id, "ap_location_id", "value_int", i)
+					EntityAddComponent(ap_pedestal_id, "LuaComponent", {
+						_tags="archipelago",
+						script_item_picked_up="data/archipelago/scripts/items/ap_pedestal_processed.lua",
+					})
+					local particle_comp = EntityAddComponent(ap_pedestal_id, "SpriteParticleEmitterComponent", {
+						sprite_file="data/archipelago/entities/items/icon-useful.png",
+						lifetime=6,
+						additive=true,
+						emissive=true,
+						velocity_slowdown=5,
+						velocity_always_away_from_center=true,
+						count_min=1,
+						count_max=1,
+						emission_interval_min_frames=60,
+						emission_interval_max_frames=90,
+					})
+					-- EntityAddComponent can't set multi-value types
+					ComponentSetValue2(particle_comp, "color", 1, 1, 1, .4)
+					ComponentSetValue2(particle_comp, "color_change", 0, 0, 0, -.2)
+					ComponentSetValue2(particle_comp, "scale", 0.15, 0.15)
+					ComponentSetValue2(particle_comp, "scale_velocity", 0.2, 0.2)
+					ComponentSetValue2(particle_comp, "randomize_rotation", 0, 50)
 				else
 					ap_pedestal_id = create_foreign_item_entity(location, x, y)
 				end
-
-				addNewInternalVariable(ap_pedestal_id, "ap_location_id", "value_int", i)
-				EntityAddComponent(ap_pedestal_id, "LuaComponent", {
-					_tags="archipelago",
-					script_item_picked_up="data/archipelago/scripts/items/ap_pedestal_processed.lua",
-				})
-				local particle_comp = EntityAddComponent(ap_pedestal_id, "SpriteParticleEmitterComponent", {
-					sprite_file="data/archipelago/entities/items/icon-useful.png",
-					lifetime=6,
-					additive=true,
-					emissive=true,
-					velocity_slowdown=5,
-					velocity_always_away_from_center=true,
-					count_min=1,
-					count_max=1,
-					emission_interval_min_frames=60,
-					emission_interval_max_frames=90,
-				})
-				-- EntityAddComponent can't set multi-value types
-				ComponentSetValue2(particle_comp, "color", 1, 1, 1, .4)
-				ComponentSetValue2(particle_comp, "color_change", 0, 0, 0, -.2)
-				ComponentSetValue2(particle_comp, "scale", 0.15, 0.15)
-				ComponentSetValue2(particle_comp, "scale_velocity", 0.2, 0.2)
-				ComponentSetValue2(particle_comp, "randomize_rotation", 0, 50)
 				return true
 			end
 		end

--- a/data/archipelago/scripts/patches/extend_forge_item_convert.lua
+++ b/data/archipelago/scripts/patches/extend_forge_item_convert.lua
@@ -49,7 +49,9 @@ local function ap_extend_forge_item_convert()
 				if ( item_name == "$ap_chest_random" ) then
 					EntityKill(id)
 					EntityLoad("data/entities/props/physics_skateboard.xml", x, y)
-					EntityLoad("data/entities/animals/longleg.xml", x, y-10)
+					local hamis = EntityLoad("data/entities/animals/longleg.xml", x, y-10)
+					local ai_comp = EntityGetFirstComponent(hamis, "AnimalAIComponent")
+					ComponentSetValue2(ai_comp, "mAggression", 0)
 				end
 			end
 		end

--- a/data/archipelago/scripts/patches/extend_forge_item_convert.lua
+++ b/data/archipelago/scripts/patches/extend_forge_item_convert.lua
@@ -39,6 +39,21 @@ local function ap_extend_forge_item_convert()
 			converted = true
 		end
 	end
+	for _, id in pairs(EntityGetInRadiusWithTag(pos_x, pos_y, 70, "ap_chest")) do
+		if EntityGetRootEntity(id) == id then
+			local x, y = EntityGetTransform(id)
+			local item_comps = EntityGetComponent( id, "ItemComponent" ) or {}
+			local item_name
+			for _, itemc in ipairs(item_comps) do
+				item_name = ComponentGetValue( itemc, "item_name" )
+				if ( item_name == "$ap_chest_random" ) then
+					EntityKill(id)
+					EntityLoad("data/entities/props/physics_skateboard.xml", x, y)
+					EntityLoad("data/entities/animals/longleg.xml", x, y-10)
+				end
+			end
+		end
+	end
 	if converted then
 		GameTriggerMusicFadeOutAndDequeueAll( 3.0 )
 		GameTriggerMusicEvent( "music/oneshot/dark_01", true, pos_x, pos_y )


### PR DESCRIPTION
Also fixed a duplicate material color definition, as the gorilla glass and ap chest had the same color (woops)