### PR TITLE
Fix for items not spawning in starting cave sometimes (hopefully)

### DIFF
--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -17,7 +17,7 @@ function not_empty(s)
 end
 
 
-local function get_player()
+function get_player()
 	return EntityGetWithTag("player_unit")[1]
 end
 
@@ -152,12 +152,6 @@ function DecreaseExtraLife(entity_id)
 		end
 	end
 	return false
-end
-
-
-function isMovingRight()
-	local control = EntityGetFirstComponent(get_player(), "ControlsComponent")
-	return ComponentGetValue2(control, "mButtonDownRight")
 end
 
 

--- a/init.lua
+++ b/init.lua
@@ -648,9 +648,11 @@ local function CheckGlobalsAndFlags()
 end
 
 
-local function CheckPlayerMovement()
-	local movement = isMovingRight()
-	if movement then
+local function CheckPlayerEntered()
+	local player_id = get_player() or -1
+	local x, _ = EntityGetTransform(player_id) or 0
+	if x > 575 then
+		print("setting load key in CheckPlayerEntered")
 		GlobalsSetValue(LOAD_KEY, "1")
 	end
 end
@@ -670,7 +672,7 @@ function OnWorldPostUpdate()
 		CheckGlobalsAndFlags()
 	end
 	if GlobalsGetValue(LOAD_KEY, "0") == "0" then
-		CheckPlayerMovement()
+		CheckPlayerEntered()
 	end
 end
 


### PR DESCRIPTION
If player holds the right key during the intro logos, they'll count as moving right before items spawn in the starting cave, making them not spawn on new game.

Fixed by making it so instead of checking whether the player has moved right, we're checking if they've walked a good distance into the cave.

The only edge case I can think of here is if the player's internet is so goddamn bad that they can be playing for long enough that they can get into the cave before they receive their items message. In which case, the advice there would be to wait at the entrance for your items to spawn before continuing.