### PR TITLE
Slot co-op and fixes to spawning items on first connection

### DIFF
--- a/data/archipelago/scripts/ap_orb_init_randomizer_spawned.lua
+++ b/data/archipelago/scripts/ap_orb_init_randomizer_spawned.lua
@@ -8,7 +8,7 @@ local orbcomp = EntityGetComponent( entity_id, "OrbComponent" )
 local orb_id = tonumber(GlobalsGetValue("ap_orb_id"))
 
 if orb_id == nil then
-	orb_id = 20
+	orb_id = 53
 end
 
 --for _, comp_id in pairs(orbcomp) do
@@ -16,7 +16,7 @@ end
 --end
 
 for _, comp_id in pairs(orbcomp) do
-	ComponentSetValue( comp_id, "orb_id", orb_id )
+	ComponentSetValue( comp_id, "orb_id", orb_id + 33)
 end
 
 orb_id = orb_id + 1

--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -307,6 +307,7 @@ function create_foreign_item_entity(location, x, y)
 end
 
 
+-- todo: figure out if it will remove items that are far away from the player, like in a shop you passed by
 -- for use with same slot co-op
 function remove_slot_coop_item(location_id)
 	local ap_entities = EntityGetWithTag("my_ap_item")

--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -313,7 +313,7 @@ function remove_slot_coop_item(location_id)
 	local ap_entities = EntityGetWithTag("my_ap_item")
 	for _, entity_id in pairs(ap_entities) do
 		print(_, entity_id)
-		local stored_location_id = getInternalVariableValue(entity_id, "ap_location_id", "value_string")
+		local stored_location_id = getInternalVariableValue(entity_id, "ap_location_id", "value_int")
 		if stored_location_id == location_id then
 			print("removed entity because slot coop partner picked it up already")
 			EntityKill(entity_id)

--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -311,7 +311,7 @@ end
 function remove_slot_coop_item(location_id)
 	local ap_entities = EntityGetWithTag("my_ap_item")
 	for entity_id in ap_entities do
-		local stored_location_id = getInternalVariableValue(entity_id, "ap_location_id", "value_int")
+		local stored_location_id = getInternalVariableValue(entity_id, "ap_location_id", "value_string")
 		if stored_location_id == location_id then
 			print("removed entity because slot coop partner picked it up already")
 			EntityKill(entity_id)

--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -311,7 +311,8 @@ end
 -- for use with same slot co-op
 function remove_slot_coop_item(location_id)
 	local ap_entities = EntityGetWithTag("my_ap_item")
-	for entity_id in ap_entities do
+	for _, entity_id in pairs(ap_entities) do
+		print(_, entity_id)
 		local stored_location_id = getInternalVariableValue(entity_id, "ap_location_id", "value_string")
 		if stored_location_id == location_id then
 			print("removed entity because slot coop partner picked it up already")

--- a/data/archipelago/scripts/ap_utils.lua
+++ b/data/archipelago/scripts/ap_utils.lua
@@ -284,11 +284,11 @@ function create_our_item_entity(item, x, y)
 			return perk_spawn(x, y, item.perk, true)
 		elseif item.items ~= nil and #item.items > 0 then
 			-- our item is something else (random choice)
-		local entity_id = EntityLoad(item.items[Random(1, #item.items)], x, y)
-		local life_comp = EntityGetFirstComponent(entity_id, "LifetimeComponent", "enabled_in_world")
-		if life_comp ~= nil then
-			EntityRemoveComponent(entity_id, life_comp)
-		end
+			local entity_id = EntityLoad(item.items[Random(1, #item.items)], x, y)
+			local life_comp = EntityGetFirstComponent(entity_id, "LifetimeComponent", "enabled_in_world")
+			if life_comp ~= nil then
+				EntityRemoveComponent(entity_id, life_comp)
+			end
 		return entity_id
 		else
 			Log.Error("Failed to load our own item at x = " .. x .. ", y = " .. y)
@@ -304,6 +304,19 @@ function create_foreign_item_entity(location, x, y)
 	-- Change item name
 	change_entity_ingame_name(entity_id, name, description)
 	return entity_id
+end
+
+
+-- for use with same slot co-op
+function remove_slot_coop_item(location_id)
+	local ap_entities = EntityGetWithTag("my_ap_item")
+	for entity_id in ap_entities do
+		local stored_location_id = getInternalVariableValue(entity_id, "ap_location_id", "value_int")
+		if stored_location_id == location_id then
+			print("removed entity because slot coop partner picked it up already")
+			EntityKill(entity_id)
+		end
+	end
 end
 
 

--- a/data/archipelago/scripts/constants.lua
+++ b/data/archipelago/scripts/constants.lua
@@ -20,6 +20,7 @@ return {
 
 	-- Item IDs for items where we want to spawn them a little differently
 	HEART_ITEM_ID = 110001,
+	REFRESH_ITEM_ID = 110002,
 	POTION_ITEM_ID = 110003,
 	FIRST_WAND_ITEM_ID = 110006,
 	LAST_WAND_ITEM_ID = 110012,

--- a/data/archipelago/scripts/first_connect_flag_remover.lua
+++ b/data/archipelago/scripts/first_connect_flag_remover.lua
@@ -1,0 +1,1 @@
+GameRemoveFlagRun("ap_first_time_connected")

--- a/data/archipelago/scripts/item_mappings.lua
+++ b/data/archipelago/scripts/item_mappings.lua
@@ -18,7 +18,6 @@ return {
 	[110010] = { items = { "data/entities/items/wand_level_05.xml", "data/entities/items/wand_unshuffle_05.xml" }, redeliverable = true, newgame = true, wand = true },
 	[110011] = { items = { "data/entities/items/wand_level_06.xml", "data/entities/items/wand_unshuffle_06.xml" }, redeliverable = true, newgame = true, wand = true },
 	[110012] = { items = { "data/archipelago/entities/items/ap_kantele.xml" }, redeliverable = true, newgame = true, wand = true },
-	-- todo: make this kantele spawn with certain spells
 
 	[110013] = { perk = "PROTECTION_FIRE", redeliverable = true, newgame = true },
 	[110014] = { perk = "PROTECTION_RADIOACTIVITY", redeliverable = true, newgame = true },

--- a/data/archipelago/scripts/item_utils.lua
+++ b/data/archipelago/scripts/item_utils.lua
@@ -105,7 +105,7 @@ function NGSpawnItems(item_counts)
 		
 		elseif item == AP.MAP_PERK_ID then
 			-- spawn the map perk on the ground, in case you find it distracting
-			perk_spawn(813, -90, item_table[item].perk)
+			perk_spawn(813, -96, item_table[item].perk)
 			item_counts[item] = nil
 			
 		elseif item_table[item].perk ~= nil then

--- a/data/archipelago/scripts/items/ap_chest_random.lua
+++ b/data/archipelago/scripts/items/ap_chest_random.lua
@@ -25,6 +25,7 @@ function on_open(entity_item)
 				local item_id = location.item_id
 				if location.is_our_item then
 					SpawnItem(item_id, true)
+					GameAddFlagRun("ap" .. i)
 				end
 				item_spawned = true
 				break

--- a/data/archipelago/scripts/items/ap_pedestal_processed.lua
+++ b/data/archipelago/scripts/items/ap_pedestal_processed.lua
@@ -6,5 +6,6 @@ dofile_once("data/archipelago/scripts/ap_utils.lua")
 -- Called when the entity is picked up
 function item_pickup(entity_item, entity_who_picked, name)
 	local location_id = getInternalVariableValue(entity_item, "ap_location_id", "value_int")
+	GameAddFlagRun("ap" .. location_id)
 	Globals.LocationUnlockQueue:append(location_id)
 end

--- a/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
+++ b/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
@@ -43,9 +43,11 @@ local function APPedestalReplacer()
 				end
 
 				local item = item_table[item_id]
-				local ap_pedestal_id = nil
+				local ap_pedestal_id
 				if location.is_our_item and item and item_id ~= AP.TRAP_ID then
 					ap_pedestal_id = create_our_item_entity(item, x, y)
+					EntityAddTag(ap_pedestal_id, "my_ap_item")
+					-- this gives the pedestal items that ap logo particle effect so you can tell it's your item
 					local particle_comp = EntityAddComponent(ap_pedestal_id, "SpriteParticleEmitterComponent", {
 						sprite_file="data/archipelago/entities/items/icon-useful.png",
 						lifetime=6,

--- a/data/archipelago/scripts/shopitem_processed.lua
+++ b/data/archipelago/scripts/shopitem_processed.lua
@@ -84,5 +84,6 @@ function item_pickup(entity_item, entity_who_picked, name)
 	local data = get_transferred_values(entity_item)
 	local component_id = get_variable_storage_component(entity_item, "ap_shop_data")
 	EntityRemoveComponent(entity_item, component_id)
+	GameAddFlagRun("ap" .. data.location_id)
 	Globals.LocationUnlockQueue:append(data.location_id)
 end

--- a/data/archipelago/scripts/shopitem_utils.lua
+++ b/data/archipelago/scripts/shopitem_utils.lua
@@ -40,8 +40,8 @@ function ShopItems.create_our_item_entity(item, x, y)
 		-- our item is something else (random choice)
 		local entity_id = EntityLoad(item.items[Random(1, #item.items)], x, y)
 		if item.gold_amount ~= 0 then
-				local life_comp = EntityGetFirstComponent(entity_id, "LifetimeComponent", "enabled_in_world")
-				EntityRemoveComponent(entity_id, life_comp)
+			local life_comp = EntityGetFirstComponent(entity_id, "LifetimeComponent", "enabled_in_world")
+			EntityRemoveComponent(entity_id, life_comp)
 		end
 		return entity_id
 	else -- error?
@@ -102,7 +102,10 @@ function ShopItems.generate_ap_shop_item_entity(location_id, x, y)
 	local item = item_table[item_id]
 
 	if location.is_our_item and item and item_id ~= AP.TRAP_ID then
-		return ShopItems.create_our_item_entity(item, x, y), false
+		local shop_item_id = ShopItems.create_our_item_entity(item, x, y)
+		EntityAddTag(shop_item_id, "my_ap_item")
+		addNewInternalVariable(shop_item_id, "ap_location_id", "value_string", location_id)
+		return shop_item_id, false
 	else
 		return ShopItems.create_foreign_item_entity(location, x, y), true
 	end

--- a/data/archipelago/scripts/shopitem_utils.lua
+++ b/data/archipelago/scripts/shopitem_utils.lua
@@ -35,10 +35,13 @@ end -- generate_item_price
 -- Spawn in an item or perk entity for the shop
 function ShopItems.create_our_item_entity(item, x, y)
 	if item.perk ~= nil then
-		return perk_spawn(x, y, item.perk, true)
+		local perk_id = perk_spawn(x, y, item.perk, true)
+		EntityAddTag(perk_id, "my_ap_item")
+		return perk_id
 	elseif item.items ~= nil and #item.items > 0 then
 		-- our item is something else (random choice)
 		local entity_id = EntityLoad(item.items[Random(1, #item.items)], x, y)
+		EntityAddTag(entity_id, "my_ap_item")
 		if item.gold_amount ~= 0 then
 			local life_comp = EntityGetFirstComponent(entity_id, "LifetimeComponent", "enabled_in_world")
 			EntityRemoveComponent(entity_id, life_comp)
@@ -104,7 +107,7 @@ function ShopItems.generate_ap_shop_item_entity(location_id, x, y)
 	if location.is_our_item and item and item_id ~= AP.TRAP_ID then
 		local shop_item_id = ShopItems.create_our_item_entity(item, x, y)
 		EntityAddTag(shop_item_id, "my_ap_item")
-		addNewInternalVariable(shop_item_id, "ap_location_id", "value_string", location_id)
+		addNewInternalVariable(shop_item_id, "ap_location_id", "value_int", location_id)
 		return shop_item_id, false
 	else
 		return ShopItems.create_foreign_item_entity(location, x, y), true

--- a/init.lua
+++ b/init.lua
@@ -256,25 +256,6 @@ function SendConnect()
 end
 
 
--- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#Set
-function SendSet(key, default, want_reply, operations)
-	SendCmd("Set", {
-		key = key,
-		default = default,
-		want_reply = want_reply,
-		operations = {operations}
-	})
-end
-
-
--- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#Get
-function SendGet(keys)
-	SendCmd("Get", {
-		keys = {keys}
-	})
-end
-
-
 local function SpawnReceivedItem(item)
 	local item_id = item["item"]
 	if ShouldDeliverItem(item) then
@@ -324,7 +305,6 @@ function RECV_MSG.Connected(msg)
 	Globals.PlayerSlot:set(current_player_slot)
 	ConnIcon:setConnected()
 
-	--SendGet("noita_" .. current_player_slot)
 	GameRemoveFlagRun("ap_spawn_kill_saver")
 	SetTimeOut(2, "data/archipelago/scripts/spawn_kill_saver.lua")
 	RestoreNewGameItems()
@@ -438,45 +418,6 @@ function RECV_MSG.ReceivedItems(msg)
 end
 
 
--- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#RoomUpdate
--- [{"cmd":"RoomUpdate","hint_points":2,"checked_locations":[110002]}] when you pick up an item
--- when someone else checks a location, this is not sent. It is only sent when you send a location check.
-function RECV_MSG.RoomUpdate(msg)
-	local locations = msg["checked_locations"] or {}
-	for k, v in pairs(locations) do
-		print(k, v)
-		--if GameHasFlagRun("ap" .. v) then
-			--remove_slot_coop_item(v)
-		--end
-	end
-end
-
-
--- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#Retrieved
-function RECV_MSG.Retrieved(msg)
-	local keys = msg["keys"] -- dict[str, any]
-	--GameAddFlagRun("ap_retrieved_responded")
-	print("retrieved is happening here")
-	-- todo: remove this and other commented out stuff once we have the first connection stuff working
-	--if keys["noita_" .. current_player_slot] == nil then
-	--	print("first time connecting, do first time connected things")
-	--	GameAddFlagRun("ap_first_time_connected")
-	--	SendSet("noita_" .. current_player_slot, 0, false, {operation = "replace", value = 1})
-	--	SetTimeOut(10, "data/archipelago/scripts/first_connect_flag_remover.lua")
-	--end
-end
-
-
--- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#SetReply
-function RECV_MSG.SetReply(msg)
-	-- nothing yet, we aren't using this for anything at the moment, but it's here
-	local key = msg["key"]
-	local value = msg["value"]
-	local original_value = msg["original value"]
-	print("received set reply with contents " .. key, value, original_value)
-end
-
-
 local function ParseJSONPart(part)
 	local result = ""
 	if part["type"] == "player_id" then
@@ -536,7 +477,7 @@ function RECV_MSG.PrintJSON(msg)
 			countdown_fun()
 			GamePrint("GO!")
 		else
-			-- it displays 10 twice otherwise
+			-- it displays the first number twice otherwise
 			if countdown_number ~= prev_countdown_number then
 				GamePrint(countdown_number)
 			end

--- a/init.lua
+++ b/init.lua
@@ -429,6 +429,17 @@ function RECV_MSG.ReceivedItems(msg)
 end
 
 
+function RECV_MSG.RoomUpdate(msg)
+	local players = msg["players"] -- list in format [ { "team": 0, "slot": 1, "alias": "Alias Name", "name": "Slot Name"} , ]
+	local locations = msg["checked_locations"] -- list[int]
+	if locations then
+		for id in locations do
+			remove_slot_coop_item(id)
+		end
+	end
+end
+
+
 local function ParseJSONPart(part)
 	local result = ""
 	if part["type"] == "player_id" then

--- a/init.lua
+++ b/init.lua
@@ -284,7 +284,7 @@ local function SpawnAllNewGameItems(first_connect_msg)
 			local item_id = item["item"]
 			if item_table[item_id].newgame then
 				ng_items[item_id] = (ng_items[item_id] or 0) + 1
-			elseif item_table[item_id].redeliverable and item_id ~= AP.REFRESH_ITEM_ID then
+			elseif item_table[item_id].redeliverable then
 				SpawnReceivedItem(item)
 			end
 		end
@@ -429,6 +429,7 @@ function RECV_MSG.ReceivedItems(msg)
 end
 
 
+-- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#RoomUpdate
 function RECV_MSG.RoomUpdate(msg)
 	local players = msg["players"] -- list in format [ { "team": 0, "slot": 1, "alias": "Alias Name", "name": "Slot Name"} , ]
 	local locations = msg["checked_locations"] -- list[int]
@@ -437,6 +438,27 @@ function RECV_MSG.RoomUpdate(msg)
 			remove_slot_coop_item(id)
 		end
 	end
+end
+
+
+-- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#Retrieved
+function RECV_MSG.Retrieved(msg)
+	local keys = msg["keys"] -- dict[str, any]
+	-- todo: something here so that we are checking if it is our first load of the multiworld or not
+	print("received Retrieved packet with some keys and values probably")
+	for k, v in pairs(keys) do
+		print(k, v)
+	end
+end
+
+
+-- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#SetReply
+function RECV_MSG.SetReply(msg)
+	-- nothing yet
+	local key = msg["key"]
+	local value = msg["value"]
+	local original_value = msg["original value"]
+	print("received set reply with contents " .. key, value, original_value)
 end
 
 

--- a/init.lua
+++ b/init.lua
@@ -465,7 +465,7 @@ function RECV_MSG.Retrieved(msg)
 		print("first time connecting, do first time connected things")
 		GameAddFlagRun("ap_first_time_connected")
 		SendSet("noita_" .. current_player_slot, 0, false, {operation = "replace", value = 1})
-		--SetTimeOut(2, "data/archipelago/scripts/spawn_kill_saver.lua")
+		SetTimeOut(10, "data/archipelago/scripts/first_connect_flag_remover.lua")
 	end
 end
 

--- a/init.lua
+++ b/init.lua
@@ -447,12 +447,12 @@ end
 -- [{"cmd":"RoomUpdate","hint_points":2,"checked_locations":[110002]}] when you pick up an item
 -- when someone else checks a location, this is not sent. It is only sent when you send a location check.
 function RECV_MSG.RoomUpdate(msg)
-	local locations = msg["checked_locations"]
+	local locations = msg["checked_locations"] or {}
 	for k, v in pairs(locations) do
 		print(k, v)
-		if GameHasFlagRun("ap" .. v) then
-			remove_slot_coop_item(v)
-		end
+		--if GameHasFlagRun("ap" .. v) then
+			--remove_slot_coop_item(v)
+		--end
 	end
 end
 

--- a/init.lua
+++ b/init.lua
@@ -289,26 +289,12 @@ end
 
 local function SpawnAllNewGameItems()
 	local ng_items = {}
-	--if first_connect_msg then
-	--	local next_item_index = 0
-	--	for i, item in ipairs(first_connect_msg["items"]) do
-	--		local current_item_index = next_item_index + i
-	--		Cache.ItemDelivery:set(current_item_index, item)
-	--		local item_id = item["item"]
-	--		if item_table[item_id].newgame then
-	--			ng_items[item_id] = (ng_items[item_id] or 0) + 1
-	--		elseif item_table[item_id].redeliverable then
-	--			SpawnReceivedItem(item)
-	--		end
-	--	end
-	--else
-		for _, item in ipairs(Cache.ItemDelivery:reference()) do
-			local item_id = item["item"]
-			if item_table[item_id].newgame then
-				ng_items[item_id] = (ng_items[item_id] or 0) + 1
-			end
+	for _, item in ipairs(Cache.ItemDelivery:reference()) do
+		local item_id = item["item"]
+		if item_table[item_id].newgame then
+			ng_items[item_id] = (ng_items[item_id] or 0) + 1
 		end
-	--end
+	end
 	Log.Info("spawning starting items: " .. JSON:encode(ng_items))
 
 	NGSpawnItems(ng_items)
@@ -426,7 +412,6 @@ function RECV_MSG.ReceivedItems(msg)
 
 	local orb_count = 0
 	local is_first_time_connected = Cache.ItemDelivery:num_items() == 0
-	local spawn_kill_saver = GameHasFlagRun("ap_spawn_kill_saver") -- True a couple seconds after Connected
 	for i, item in ipairs(msg["items"]) do
 		local current_item_index = next_item_index + i
 
@@ -434,6 +419,8 @@ function RECV_MSG.ReceivedItems(msg)
 		if not Cache.ItemDelivery:is_set(current_item_index) then
 			Cache.ItemDelivery:set(current_item_index, item)
 			local item_id = item["item"]
+			-- when connected for the first time, you get receiveditems along with connected
+			-- but also, you want to give the player gold and stuff that got sent before spawning
 			if is_first_time_connected and not item_table[item_id].newgame and item_table[item_id].redeliverable then
 				SpawnReceivedItem(item)
 			elseif not is_first_time_connected then

--- a/init.lua
+++ b/init.lua
@@ -338,7 +338,7 @@ function RECV_MSG.Connected(msg)
 	Globals.PlayerSlot:set(current_player_slot)
 	ConnIcon:setConnected()
 
-	SendGet("noita_" .. current_player_slot)
+	--SendGet("noita_" .. current_player_slot)
 
 	SetTimeOut(2, "data/archipelago/scripts/spawn_kill_saver.lua")
 	RestoreNewGameItems()
@@ -425,9 +425,8 @@ function RECV_MSG.ReceivedItems(msg)
 	end
 
 	local orb_count = 0
-	if GameHasFlagRun("ap_first_time_connected") then
+	if not Cache.ItemDelivery:is_set(1) and not GameHasFlagRun("ap_spawn_kill_saver") then
 		SpawnAllNewGameItems(msg)
-		GameRemoveFlagRun("ap_first_time_connected")
 	end
 	for i, item in ipairs(msg["items"]) do
 		local current_item_index = next_item_index + i
@@ -461,12 +460,15 @@ end
 -- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#Retrieved
 function RECV_MSG.Retrieved(msg)
 	local keys = msg["keys"] -- dict[str, any]
-	if keys["noita_" .. current_player_slot] == nil then
-		print("first time connecting, do first time connected things")
-		GameAddFlagRun("ap_first_time_connected")
-		SendSet("noita_" .. current_player_slot, 0, false, {operation = "replace", value = 1})
-		SetTimeOut(10, "data/archipelago/scripts/first_connect_flag_remover.lua")
-	end
+	--GameAddFlagRun("ap_retrieved_responded")
+	print("retrieved is happening here")
+	-- todo: remove this and other commented out stuff once we have the first connection stuff working
+	--if keys["noita_" .. current_player_slot] == nil then
+	--	print("first time connecting, do first time connected things")
+	--	GameAddFlagRun("ap_first_time_connected")
+	--	SendSet("noita_" .. current_player_slot, 0, false, {operation = "replace", value = 1})
+	--	SetTimeOut(10, "data/archipelago/scripts/first_connect_flag_remover.lua")
+	--end
 end
 
 

--- a/init.lua
+++ b/init.lua
@@ -339,7 +339,7 @@ function RECV_MSG.Connected(msg)
 	ConnIcon:setConnected()
 
 	--SendGet("noita_" .. current_player_slot)
-
+	GameRemoveFlagRun("ap_spawn_kill_saver")
 	SetTimeOut(2, "data/archipelago/scripts/spawn_kill_saver.lua")
 	RestoreNewGameItems()
 

--- a/init.lua
+++ b/init.lua
@@ -465,13 +465,14 @@ function RECV_MSG.Retrieved(msg)
 		print("first time connecting, do first time connected things")
 		GameAddFlagRun("ap_first_time_connected")
 		SendSet("noita_" .. current_player_slot, 0, false, {operation = "replace", value = 1})
+		--SetTimeOut(2, "data/archipelago/scripts/spawn_kill_saver.lua")
 	end
 end
 
 
 -- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#SetReply
 function RECV_MSG.SetReply(msg)
-	-- nothing yet
+	-- nothing yet, we aren't using this for anything at the moment, but it's here
 	local key = msg["key"]
 	local value = msg["value"]
 	local original_value = msg["original value"]

--- a/init.lua
+++ b/init.lua
@@ -425,7 +425,7 @@ function RECV_MSG.ReceivedItems(msg)
 	end
 
 	local orb_count = 0
-	if not Cache.ItemDelivery:is_set(1) and not GameHasFlagRun("ap_spawn_kill_saver") then
+	if Cache.ItemDelivery:num_items() == 0 and not GameHasFlagRun("ap_spawn_kill_saver") then
 		SpawnAllNewGameItems(msg)
 	end
 	for i, item in ipairs(msg["items"]) do

--- a/init.lua
+++ b/init.lua
@@ -143,11 +143,19 @@ end
 
 
 local function ShouldDeliverItem(item)
+	local item_id = item["item"]
+	local location_id = item["location"]
 	if item["player"] == current_player_slot then
-		if item["location"] >= AP.FIRST_SHOP_LOCATION_ID and item["location"] <= AP.LAST_SHOP_LOCATION_ID then
-			return false	-- Don't deliver shopitems, they are given locally
-		elseif item["location"] >= AP.FIRST_BIOME_LOCATION_ID and item["location"] <= AP.LAST_BIOME_LOCATION_ID then
-			return false	-- Don't deliver biome items, they are given locally
+		if GameHasFlagRun("ap" .. item_id) then
+			if location_id >= AP.FIRST_SHOP_LOCATION_ID and location_id <= AP.LAST_SHOP_LOCATION_ID then
+				return false	-- Don't deliver shopitems, they are given locally
+			elseif location_id >= AP.FIRST_BIOME_LOCATION_ID and location_id <= AP.LAST_BIOME_LOCATION_ID then
+				return false	-- Don't deliver biome items, they are given locally
+			end
+			GameRemoveFlagRun("ap" .. item_id)
+		else
+			-- this is an item your co-op partner picked up in slot co-op
+			remove_slot_coop_item(location_id)
 		end
 	end
 	return true
@@ -362,6 +370,7 @@ end
 
 local function SpawnReceivedItem(item)
 	local item_id = item["item"]
+	GameAddFlagRun("ap" .. item_id)
 	if ShouldDeliverItem(item) then
 		if GameHasFlagRun("ap_spawn_kill_saver") then
 			SpawnItem(item_id, true)

--- a/init.lua
+++ b/init.lua
@@ -259,7 +259,6 @@ end
 
 local function SpawnReceivedItem(item)
 	local item_id = item["item"]
-	GameAddFlagRun("ap" .. item_id)
 	if ShouldDeliverItem(item) then
 		if GameHasFlagRun("ap_spawn_kill_saver") then
 			SpawnItem(item_id, true)
@@ -430,13 +429,12 @@ end
 
 
 -- https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#RoomUpdate
+-- [{"cmd":"RoomUpdate","hint_points":2,"checked_locations":[110002]}] when you pick up an item
+-- when someone else checks a location, this is not sent. It is only sent when you send a location check.
 function RECV_MSG.RoomUpdate(msg)
-	local players = msg["players"] -- list in format [ { "team": 0, "slot": 1, "alias": "Alias Name", "name": "Slot Name"} , ]
-	local locations = msg["checked_locations"] -- list[int]
-	if locations then
-		for id in locations do
-			remove_slot_coop_item(id)
-		end
+	local location_id = msg["checked_locations"]
+	if GameHasFlagRun("ap" .. location_id) then
+		remove_slot_coop_item(location_id)
 	end
 end
 


### PR DESCRIPTION
Slot co-op now works as expected. If someone picks up an item and that item is on a pedestal or in the shop, it should be delivered to the other person playing, and remove that item from the world for that player. I didn't test this part yet as it is hard to test solo, but at the very least it didn't seem to impact anything while playing without slot co-op.

Also fixed the items spawning weirdly on first connection. I tested this a few times with different set ups, and tested it in the RC5 Async. It worked every time -- gave you your normal item spawns in the starting cave and gave you your gold and extra lives that were sent before you connected (since it would be dumb if you didn't get them on your very first spawn into the session).