### PR TITLE
Added option to change what art shows up on the randomizer-spawned orbs

### DIFF
--- a/data/archipelago/entities/items/orbs/vanilla_orb.xml
+++ b/data/archipelago/entities/items/orbs/vanilla_orb.xml
@@ -1,0 +1,20 @@
+<Sprite 
+	filename="data/items_gfx/orbs/orb_discovered.png" 
+	offset_x="20" 
+	offset_y="48"
+	default_animation="default"
+	>
+	
+	<RectAnimation
+		name="default"
+		pos_x="0"
+		pos_y="0"
+		frame_count="7"
+		frame_width="40"
+		frame_height="50"
+		frame_wait="0.12"
+		frames_per_row="7"
+		loop="1"
+		>
+  </RectAnimation>
+</Sprite>

--- a/data/archipelago/scripts/ap_orb_init_randomizer_spawned.lua
+++ b/data/archipelago/scripts/ap_orb_init_randomizer_spawned.lua
@@ -27,8 +27,6 @@ local sprite_image = "ap_orb"
 
 local orb_art_setting = ModSettingGet("archipelago.orb_art")
 
-print("orb art setting")
-print(orb_art_setting)
 
 if orb_art_setting == "Vanilla" then
 	sprite_image = "vanilla_orb"

--- a/data/archipelago/scripts/ap_orb_init_randomizer_spawned.lua
+++ b/data/archipelago/scripts/ap_orb_init_randomizer_spawned.lua
@@ -1,8 +1,10 @@
 dofile( "data/scripts/game_helpers.lua" )
 dofile_once("data/scripts/lib/utilities.lua")
+dofile_once("data/scripts/lib/mod_settings.lua")
 
 local entity_id = GetUpdatedEntityID()
 local pos_x, pos_y = EntityGetTransform( entity_id )
+
 
 local orbcomp = EntityGetComponent( entity_id, "OrbComponent" )
 local orb_id = tonumber(GlobalsGetValue("ap_orb_id"))
@@ -11,10 +13,6 @@ if orb_id == nil then
 	orb_id = 53
 end
 
---for _, comp_id in pairs(orbcomp) do
---	ComponentGetValue2( comp_id, "orb_id")
---end
-
 for _, comp_id in pairs(orbcomp) do
 	ComponentSetValue( comp_id, "orb_id", orb_id + 33)
 end
@@ -22,3 +20,22 @@ end
 orb_id = orb_id + 1
 
 GlobalsSetValue("ap_orb_id", tostring(orb_id))
+
+
+local spritecomp = EntityGetFirstComponent(entity_id, "SpriteComponent")
+local sprite_image = "ap_orb"
+
+local orb_art_setting = ModSettingGet("archipelago.orb_art")
+
+print("orb art setting")
+print(orb_art_setting)
+
+if orb_art_setting == "Vanilla" then
+	sprite_image = "vanilla_orb"
+elseif orb_art_setting == "spinny_logo" then
+	sprite_image = "ap_orb_woah"
+elseif orb_art_setting == "porb" then
+	sprite_image = "porb"
+end
+
+ComponentSetValue2(spritecomp, "image_file", "data/archipelago/entities/items/orbs/" .. sprite_image .. ".xml")

--- a/init.lua
+++ b/init.lua
@@ -289,9 +289,9 @@ local function RestoreNewGameItems()
 		ResetOrbID()
 		SpawnAllNewGameItems()
 
-		--if ModSettingGet("archipelago.debug_items") == true then
-		--	give_debug_items()
-		--end
+		if ModSettingGet("archipelago.debug_items") == true then
+			give_debug_items()
+		end
 	end
 end
 

--- a/settings.lua
+++ b/settings.lua
@@ -62,6 +62,12 @@ local translations = {
 	["$ap_menu_server_settings_debug_items_desc"] = {
 		en="Makes debug items and perks spawn when starting a new run."
 	},
+	["$ap_orb_art_settings_name"] = {
+		en="Orb Art"
+	},
+	["$ap_orb_art_settings_desc"] = {
+		en="Changes the appearance of orbs spawned by the randomizer.\nDoes not affect orbs spawned by the game itself."
+	}
 }
 
 local function translate(msg)
@@ -147,13 +153,27 @@ local mod_settings =
 				value_default = false,
 				scope = MOD_SETTING_SCOPE_NEW_GAME,
 			},
-			--{
-			--	id = "debug_items",
-			--	ui_name = translate("$ap_menu_server_settings_debug_items_name"),
-			--	ui_description = translate("$ap_menu_server_settings_debug_items_desc"),
-			--	value_default = false,
-			--	scope = MOD_SETTING_SCOPE_NEW_GAME,
-			--},
+			{
+				id = "orb_art",
+				ui_name = translate("$ap_orb_art_settings_name"),
+				ui_description = translate("$ap_orb_art_settings_desc"),
+				value_default = "vanilla",
+				values = {
+					{"vanilla", "Vanilla"},
+					{"ap_logo", "AP Logo"},
+					{"spinny_logo", "Spinny Logo"},
+					{"porb", "Porb"}
+				},
+				scope = MOD_SETTING_SCOPE_NEW_GAME,
+			},
+			{
+				id = "debug_items",
+				ui_name = translate("$ap_menu_server_settings_debug_items_name"),
+				ui_description = translate("$ap_menu_server_settings_debug_items_desc"),
+				value_default = false,
+				scope = MOD_SETTING_SCOPE_NEW_GAME,
+				hidden = true,
+			},
 		},
 	},
 }

--- a/settings.lua
+++ b/settings.lua
@@ -157,7 +157,7 @@ local mod_settings =
 				id = "orb_art",
 				ui_name = translate("$ap_orb_art_settings_name"),
 				ui_description = translate("$ap_orb_art_settings_desc"),
-				value_default = "vanilla",
+				value_default = "ap_logo",
 				values = {
 					{"vanilla", "Vanilla"},
 					{"ap_logo", "AP Logo"},


### PR DESCRIPTION
Only affects the orbs that are spawned by the randomizer, meaning just the orbs that actually increase your orb counter while you have the mod enabled.