### PR TITLE
Updated chest and pedestal replacers

### DIFF
--- a/data/archipelago/scripts/apply_ap_patches.lua
+++ b/data/archipelago/scripts/apply_ap_patches.lua
@@ -28,7 +28,8 @@ ModLuaFileAppend("data/entities/animals/boss_gate/gate_monster_death.lua", "data
 ModLuaFileAppend("data/scripts/items/orb_init.lua", "data/archipelago/scripts/patches/ap_orb_init_random.lua")
 ModLuaFileAppend("data/scripts/items/orb_pickup.lua", "data/archipelago/scripts/patches/ap_orb_pickup_random.lua")
 
-ModLuaFileAppend("data/scripts/biome_scripts.lua", "data/archipelago/scripts/patches/ap_heart_replacer.lua")
+ModLuaFileAppend("data/scripts/biome_scripts.lua", "data/archipelago/scripts/patches/ap_heart_and_chest_replacer.lua")
+ModLuaFileAppend("data/scripts/biomes/coalmine.lua", "data/archipelago/scripts/patches/ap_heart_and_chest_replacer.lua")
 ModLuaFileAppend("data/scripts/biome_scripts.lua", "data/archipelago/scripts/patches/ap_pedestal_replacer.lua")
 ModLuaFileAppend("data/scripts/biomes/coalmine.lua", "data/archipelago/scripts/patches/ap_pedestal_replacer.lua")
 

--- a/data/archipelago/scripts/apply_ap_patches.lua
+++ b/data/archipelago/scripts/apply_ap_patches.lua
@@ -30,6 +30,7 @@ ModLuaFileAppend("data/scripts/items/orb_pickup.lua", "data/archipelago/scripts/
 
 ModLuaFileAppend("data/scripts/biome_scripts.lua", "data/archipelago/scripts/patches/ap_heart_and_chest_replacer.lua")
 ModLuaFileAppend("data/scripts/biomes/coalmine.lua", "data/archipelago/scripts/patches/ap_heart_and_chest_replacer.lua")
+ModLuaFileAppend("data/scripts/biomes/tower.lua", "data/archipelago/scripts/patches/ap_heart_and_chest_replacer.lua")
 ModLuaFileAppend("data/scripts/biome_scripts.lua", "data/archipelago/scripts/patches/ap_pedestal_replacer.lua")
 ModLuaFileAppend("data/scripts/biomes/coalmine.lua", "data/archipelago/scripts/patches/ap_pedestal_replacer.lua")
 

--- a/data/archipelago/scripts/apply_ap_patches.lua
+++ b/data/archipelago/scripts/apply_ap_patches.lua
@@ -30,5 +30,6 @@ ModLuaFileAppend("data/scripts/items/orb_pickup.lua", "data/archipelago/scripts/
 
 ModLuaFileAppend("data/scripts/biome_scripts.lua", "data/archipelago/scripts/patches/ap_heart_replacer.lua")
 ModLuaFileAppend("data/scripts/biome_scripts.lua", "data/archipelago/scripts/patches/ap_pedestal_replacer.lua")
+ModLuaFileAppend("data/scripts/biomes/coalmine.lua", "data/archipelago/scripts/patches/ap_pedestal_replacer.lua")
 
 ModLuaFileAppend("data/scripts/buildings/forge_item_convert.lua", "data/archipelago/scripts/patches/extend_forge_item_convert.lua")

--- a/data/archipelago/scripts/items/pedestal_trap_pickup.lua
+++ b/data/archipelago/scripts/items/pedestal_trap_pickup.lua
@@ -1,0 +1,16 @@
+dofile_once("data/scripts/lib/utilities.lua")
+dofile_once( "data/scripts/buildings/wand_trap.lua" )
+
+function item_pickup( entity_item, entity_who_picked, name )
+    local entity_id    = GetUpdatedEntityID()
+	local pos_x, pos_y = EntityGetTransform( entity_id )
+
+	if( entity_who_picked == entity_id ) then  return  end
+
+    local entity_tags = EntityGetTags( entity_id )
+
+    if ( string.find( entity_tags, "trap_wand" ) ~= nil ) then
+		trigger_wand_pickup_trap( pos_x, pos_y )
+	end
+
+end

--- a/data/archipelago/scripts/items/pedestal_trap_pickup.lua
+++ b/data/archipelago/scripts/items/pedestal_trap_pickup.lua
@@ -2,15 +2,14 @@ dofile_once("data/scripts/lib/utilities.lua")
 dofile_once( "data/scripts/buildings/wand_trap.lua" )
 
 function item_pickup( entity_item, entity_who_picked, name )
-    local entity_id    = GetUpdatedEntityID()
+	local entity_id    = GetUpdatedEntityID()
 	local pos_x, pos_y = EntityGetTransform( entity_id )
 
 	if( entity_who_picked == entity_id ) then  return  end
 
-    local entity_tags = EntityGetTags( entity_id )
+	local entity_tags = EntityGetTags( entity_id )
 
-    if ( string.find( entity_tags, "trap_wand" ) ~= nil ) then
+	if ( string.find( entity_tags, "trap_wand" ) ~= nil ) then
 		trigger_wand_pickup_trap( pos_x, pos_y )
 	end
-
 end

--- a/data/archipelago/scripts/patches/ap_heart_and_chest_replacer.lua
+++ b/data/archipelago/scripts/patches/ap_heart_and_chest_replacer.lua
@@ -1,13 +1,14 @@
 dofile_once("data/archipelago/scripts/ap_utils.lua")
 
-local function APHeartReplacer()
+local function APHeartAndChestReplacer()
     local Biomes = dofile("data/archipelago/scripts/ap_biome_mapping.lua")
     local Globals = dofile("data/archipelago/scripts/globals.lua")
 
-    -- sets a function for the old version of spawn_heart
+    -- sets a function for the old versions of spawn_heart and spawn_chest
 	local ap_old_spawn_heart = spawn_heart
+	local ap_old_spawn_chest = spawn_chest
 
-	local function ap_replace_heart(x, y)
+	local function ap_replace_heart_or_chest(x, y, name)
 		local biome_name = BiomeMapGetName(x, y)
 		local has_spawned = false
 		-- check if the biome has checks left, if not then just spawn a chest/heart as normal
@@ -17,7 +18,8 @@ local function APHeartReplacer()
 			-- the r given here should be exactly the same as the r given by ap_old_spawn_heart
 			local r = ProceduralRandom(x, y)
 			SetRandomSeed(x, y)
-			if r > 0.3 then
+			-- spawn_heart has a 70% chance of spawning, while spawn_chest always spawns
+			if r > 0.3 and name == "heart" or name == "chest" then
 				for i = biome_data.first_hc, biome_data.first_hc + 19 do
 					if Globals.MissingLocationsSet:has_key(i) then
 						-- spawn the chest, set ap_chest_id equal to its entity ID
@@ -31,14 +33,24 @@ local function APHeartReplacer()
 		end
 		-- chest spawned in non-applicable biome or no more chests for that biome, spawn heart/chest normally
 		if has_spawned ~= true then
-			ap_old_spawn_heart(x, y)
+			if name == "heart" then
+				ap_old_spawn_heart(x, y)
+			elseif name == "chest" then
+				ap_old_spawn_chest(x, y)
+			end
 		end
 	end
 
-	-- this makes the spawn_heart the game calls for redirect to ap_replace_heart
+	-- this is for the spawn_heart function the generic biome_scripts.lua uses
 	spawn_heart = function(x, y)
-		ap_replace_heart(x, y)
+		ap_replace_heart_or_chest(x, y, "heart")
 	end
+
+	-- this is for the spawn_chest script within individual biomes
+	spawn_chest = function(x, y)
+		ap_replace_heart_or_chest(x, y, "chest")
+	end
+
 end
 
-APHeartReplacer()
+APHeartAndChestReplacer()

--- a/data/archipelago/scripts/patches/ap_heart_and_chest_replacer.lua
+++ b/data/archipelago/scripts/patches/ap_heart_and_chest_replacer.lua
@@ -14,7 +14,6 @@ local function APHeartAndChestReplacer()
 		-- check if the biome has checks left, if not then just spawn a chest/heart as normal
 		if Biomes[biome_name] ~= nil then
 			local biome_data = Biomes[biome_name]
-			-- hearts/chests have a 30% chance not to spawn in the base game
 			-- the r given here should be exactly the same as the r given by ap_old_spawn_heart
 			local r = ProceduralRandom(x, y)
 			SetRandomSeed(x, y)
@@ -50,7 +49,6 @@ local function APHeartAndChestReplacer()
 	spawn_chest = function(x, y)
 		ap_replace_heart_or_chest(x, y, "chest")
 	end
-
 end
 
 APHeartAndChestReplacer()

--- a/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
+++ b/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
@@ -8,6 +8,7 @@ local function APPedestalReplacer()
 
 	local ap_old_spawn_wands = spawn_wands
 	local ap_old_spawn_potions = spawn_potions
+	local ap_old_spawn_trapwand = spawn_trapwand
 
 	local function ap_replace_pedestals(x, y, replaced_pedestal)
 		local biome_name = BiomeMapGetName(x, y)
@@ -18,12 +19,12 @@ local function APPedestalReplacer()
 		for i = biome_data.first_ped, biome_data.first_ped + 19 do
 			if Globals.MissingLocationsSet:has_key(i) and Globals.PedestalLocationsSet:has_key(i) then
 				-- spawn the pedestal item, tell it its ID
-				Globals.PedestalLocationsSet:remove_key(i)
+				--Globals.PedestalLocationsSet:remove_key(i)
 				local location = Globals.LocationScouts:get_key(i)
 				local item_id = location.item_id
 
 				if not location.is_our_item then
-					if replaced_pedestal == "wand" then
+					if replaced_pedestal == ("wand" or "trapwand") then
 						y = y - 6
 						x = x + 0.5
 					elseif replaced_pedestal == "potion" then
@@ -77,6 +78,12 @@ local function APPedestalReplacer()
 					_tags="archipelago",
 					script_item_picked_up="data/archipelago/scripts/items/ap_pedestal_processed.lua",
 				})
+				if replaced_pedestal == "trapwand" then
+					EntityAddTag(ap_pedestal_id, "trap_wand")
+					EntityAddComponent(ap_pedestal_id, "LuaComponent", {
+						script_item_picked_up="data/archipelago/scripts/items/pedestal_trap_pickup.lua"
+					})
+				end
 				return true
 			end
 		end
@@ -104,6 +111,21 @@ local function APPedestalReplacer()
 			end
 		else
 			ap_old_spawn_potions(x, y)
+		end
+	end
+
+	spawn_trapwand = function(x, y)
+		if GameHasFlagRun("AP_LocationInfo_received") then
+			if not ap_replace_pedestals(x, y, "trapwand") then
+				ap_old_spawn_trapwand(x, y)
+				print("vanilla trap at " .. x, y)
+			else
+				print("trap wand spawned at " .. x, y)
+			end
+		else
+			ap_old_spawn_trapwand(x, y)
+			print("trapwand pedestal spawned vanilla because it spawned beore location info was done")
+			print("this spawned at " .. x, y)
 		end
 	end
 end

--- a/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
+++ b/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
@@ -97,7 +97,6 @@ local function APPedestalReplacer()
 			end
 		else
 			ap_old_spawn_wands(x, y)
-			print("wand pedestal spawned vanilla because it spawned beore location info was done")
 		end
 	end
 
@@ -116,14 +115,10 @@ local function APPedestalReplacer()
 		if GameHasFlagRun("AP_LocationInfo_received") then
 			if not ap_replace_pedestals(x, y, "trapwand") then
 				ap_old_spawn_trapwand(x, y)
-				print("vanilla trap at " .. x, y)
 			else
-				print("trap wand spawned at " .. x, y)
 			end
 		else
 			ap_old_spawn_trapwand(x, y)
-			print("trapwand pedestal spawned vanilla because it spawned beore location info was done")
-			print("this spawned at " .. x, y)
 		end
 	end
 end

--- a/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
+++ b/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
@@ -19,7 +19,7 @@ local function APPedestalReplacer()
 		for i = biome_data.first_ped, biome_data.first_ped + 19 do
 			if Globals.MissingLocationsSet:has_key(i) and Globals.PedestalLocationsSet:has_key(i) then
 				-- spawn the pedestal item, tell it its ID
-				--Globals.PedestalLocationsSet:remove_key(i)
+				Globals.PedestalLocationsSet:remove_key(i)
 				local location = Globals.LocationScouts:get_key(i)
 				local item_id = location.item_id
 
@@ -52,10 +52,8 @@ local function APPedestalReplacer()
 					local particle_comp = EntityAddComponent(ap_pedestal_id, "SpriteParticleEmitterComponent", {
 						sprite_file="data/archipelago/entities/items/icon-useful.png",
 						lifetime=6,
-						additive=true,
-						emissive=true,
 						velocity_slowdown=5,
-						velocity_always_away_from_center=true,
+						velocity_always_away_from_center=1,
 						count_min=1,
 						count_max=1,
 						emission_interval_min_frames=60,

--- a/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
+++ b/data/archipelago/scripts/patches/ap_pedestal_replacer.lua
@@ -115,7 +115,6 @@ local function APPedestalReplacer()
 		if GameHasFlagRun("AP_LocationInfo_received") then
 			if not ap_replace_pedestals(x, y, "trapwand") then
 				ap_old_spawn_trapwand(x, y)
-			else
 			end
 		else
 			ap_old_spawn_trapwand(x, y)

--- a/data/archipelago/scripts/shopitem_processed.lua
+++ b/data/archipelago/scripts/shopitem_processed.lua
@@ -60,11 +60,15 @@ function init(entity_id)
 		z_index="-1",
 	})
 
+	local is_stealable = 0
+	if BiomeMapGetName(x, y) == "$biome_holymountain" then
+		is_stealable = 1
+	end
 	-- https://noita.wiki.gg/wiki/Documentation:_ItemCostComponent
 	EntityAddComponent(entity_id, "ItemCostComponent", { 
 		_tags="shop_cost,enabled_in_world",
 		cost=data.price,
-		stealable=BiomeMapGetName(x, y) == "$biome_holymountain"
+		stealable=is_stealable
 	})
 
 	-- https://noita.wiki.gg/wiki/Documentation:_LuaComponent


### PR DESCRIPTION
Pedestal replacer now replaces trap puzzles in the mines, as this is the only place with this type of pedestal.
Chest/heart replacer now replaces chests that get spawned with a different script in the Mines and the Tower. It only sometimes replaces them in the mines though due to that timing issue where, if the pedestal spawns before you can do your location scout stuff, they'll spawn vanilla.
Also went in and cleaned up a thing that was giving error messages. The particle effects for your own ap item on chests and the stealable quality of shop items were throwing it. As a result, this also makes shop items stealable as intended.