### PR TITLE
Added secure connection setting with proper fallbacks

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -690,8 +690,14 @@ local function CheckNetworkMessages()
 			if errmsg ~= nil then
 				ConnectionError(errmsg)
 				if errmsg:find("TLS") or errmsg:find("-2146893048") then
-					Log.Error("Something related to TLS failed, attempting to connect on unsecure protocol")
-					InitSocket(false)
+					-- if connecting with ws, try to connect with wss instead
+					if not ModSettingGet("archipelago.secure_conn") then
+						Log.Error("Something related to TLS failed, attempting to connect on a secure protocol...")
+						InitSocket(true)
+					else
+						-- if connecting with wss, don't fall back to ws, since that's going from secure to insecure
+						Log.Error("Something related to TLS failed, please check your connection settings.")
+					end
 				end
 			end
 			break
@@ -763,7 +769,11 @@ function OnModInit()
 	GameRemoveFlagRun("AP_LocationInfo_received")
 	create_dir("archipelago_cache")
 	ConnIcon:create()
-	InitSocket(true)
+	if ModSettingGet("archipelago.secure_conn") then
+		InitSocket(true)
+	else
+		InitSocket(false)
+	end
 end
 
 function OnPlayerSpawned()

--- a/settings.lua
+++ b/settings.lua
@@ -73,7 +73,13 @@ local translations = {
 	},
 	["$ap_death_link_settings_desc"] = {
 		en="When enabled, the death link setting in your Archipelago YAML will be used.\nWhen disabled, this will override your YAML and disable death link in future runs."
-	}
+	},
+	["$ap_secure_settings_name"] = {
+		en="Secure Connection"
+	},
+	["$ap_secure_settings_desc"] = {
+		en="When enabled, the game will attempt to connect to the server with a secure connection.\nIf this is disabled, it will attempt to connect with an insecure connection first, then fall back to a secure connection."
+	},
 }
 
 local function translate(msg)
@@ -143,6 +149,13 @@ local mod_settings =
 				ui_description = translate("$ap_menu_server_settings_password_desc"),
 				value_default = "",
 				text_max_length = 120,
+				scope = MOD_SETTING_SCOPE_NEW_GAME,
+			},
+			{
+				id = "secure_conn",
+				ui_name = translate("$ap_secure_settings_name"),
+				ui_description = translate("$ap_secure_settings_desc"),
+				value_default = false,
 				scope = MOD_SETTING_SCOPE_NEW_GAME,
 			},
 			{


### PR DESCRIPTION
Previous method had issues -- we started on secure and fell back to insecure. This frequently created an errant error message on connection, and isn't great security (not that security is really necessary here).

This PR adds a new setting to let you choose whether to connect on a secure or insecure connection. If you choose secure, it does not fall back to insecure if it fails. If you choose insecure, it will fall back to secure if it fails.

Draft PR because I did this in browser, and can't really test it right now.