### PR TITLE
Changed connection error messaging

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -241,7 +241,8 @@ end
 local RECV_MSG = {}
 
 local function ConnectionError(msg_str)
-	Log.Error(msg_str)
+	-- commented out since it makes the user think there's a problem when there isn't one
+	-- Log.Error(msg_str)
 	ConnIcon:setDisconnected(msg_str)
 end
 
@@ -645,6 +646,10 @@ function InitSocket(secure)
 	if secure then
 		prefix = "wss://"
 	end
+	-- if the user puts in ws:// or wss:// or http:// or https://, don't add a prefix
+	if string.find(host, "//") then
+		prefix = ""
+	end
 	local url = prefix .. host .. ":" .. port
 	Log.Info("Connecting to " .. url .. "...")
 
@@ -690,7 +695,7 @@ local function CheckNetworkMessages()
 			if errmsg ~= nil then
 				ConnectionError(errmsg)
 				if errmsg:find("TLS") or errmsg:find("-2146893048") then
-					Log.Error("Something related to TLS failed, attempting to connect on unsecure protocol")
+					Log.Error("Connecting on an unsecure protocol...")
 					InitSocket(false)
 				end
 			end

--- a/init.lua
+++ b/init.lua
@@ -614,8 +614,8 @@ end
 
 
 function RECV_MSG.RoomUpdate(msg)
-	for _, v in pairs(msg["checked_locations"]) do
-		remove_collected_item(v)
+	for _, location_ids in pairs(msg["checked_locations"]) do
+		remove_collected_item(location_ids)
 	end
 end
 


### PR DESCRIPTION
Currently, when you connect to the game on an unsecure connection, the player first sees a TLS error, then that something related to TLS failed, and then a successful connection.

This has led to a bug report about an actual connection issue being misconstrued as being related to this, making information gathering harder to actually diagnose the issue. So, changing around how these messages are shown to stop that issue from happening.

Also, made it so if you specifically put in wss:// or https://, it'll use that instead of falling back to unsecure. That way, if you're specifically trying to get a secure connection, you don't fall back to an unsecure connection.