### PR TITLE
Suppress trailing garbage message

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -21,7 +21,7 @@ local Log = dofile("data/archipelago/scripts/logger.lua")
 
 local JSON = dofile("data/archipelago/lib/json.lua")
 function JSON:onDecodeError(message, text, location, etc)
-	Log.Error(message)
+	Log.Info(message)
 end
 
 -- SCRIPTS


### PR DESCRIPTION
There's a trailing garbage message that's been showing up recently. No clue why it's showing up -- I don't think AP is sending it for a keep alive, and I don't know enough to say whether pollnet is doing it.

But, it's making a scary error message on-screen for players, and that sucks, so I'm limiting that message to just show up in logs instead.