### PR TITLE
Fix issue where you sometimes go over your orb goal amount

### DIFF
--- a/data/archipelago/entities/items/orbs/ap_orb_base_randomizer_spawned.xml
+++ b/data/archipelago/entities/items/orbs/ap_orb_base_randomizer_spawned.xml
@@ -1,4 +1,4 @@
-<Entity tags="hittable,teleportable_NOT,polymorphable_NOT,ap_item">
+<Entity tags="hittable,teleportable_NOT,polymorphable_NOT,ap_item,ap_orb">
 	
 	<VelocityComponent>
 	</VelocityComponent>

--- a/data/archipelago/scripts/ap_orb_pickup_randomizer_spawned.lua
+++ b/data/archipelago/scripts/ap_orb_pickup_randomizer_spawned.lua
@@ -3,9 +3,21 @@ dofile_once("data/scripts/lib/utilities.lua")
 
 function item_pickup( entity_item, entity_who_picked, item_name )
 	local pos_x, pos_y = EntityGetTransform( entity_item )
-
 	local message_title = "$itempickup_orb_discovered"
 	local message_desc = "$itempickupdesc_orb_discovered"
+
+	local orb_count = GameGetOrbCountThisRun()
+
+	-- if you reach your goal amount and there are orbs on the ground still, remove their orb components so you don't go over your goal amount
+	if (GameHasFlagRun("ap_peaceful_goal") and orb_count >= 33) or (GameHasFlagRun("ap_pure_goal") and orb_count >= 11) then
+		local existing_orbs = EntityGetWithTag("ap_orb")
+		for _, orb in pairs(existing_orbs) do
+			local orb_comp = EntityGetFirstComponent(orb, "OrbComponent")
+			if orb_comp then
+				EntityRemoveComponent(orb, orb_comp)
+			end
+		end
+	end
 
 	EntityLoad( "data/entities/items/pickup/heart.xml", pos_x, pos_y )
 

--- a/data/archipelago/scripts/ap_orb_pickup_randomizer_spawned.lua
+++ b/data/archipelago/scripts/ap_orb_pickup_randomizer_spawned.lua
@@ -10,12 +10,9 @@ function item_pickup( entity_item, entity_who_picked, item_name )
 
 	-- if you reach your goal amount and there are orbs on the ground still, remove their orb components so you don't go over your goal amount
 	if (GameHasFlagRun("ap_peaceful_goal") and orb_count >= 33) or (GameHasFlagRun("ap_pure_goal") and orb_count >= 11) then
-		local existing_orbs = EntityGetWithTag("ap_orb")
-		for _, orb in pairs(existing_orbs) do
-			local orb_comp = EntityGetFirstComponent(orb, "OrbComponent")
-			if orb_comp then
-				EntityRemoveComponent(orb, orb_comp)
-			end
+		local orb_comp = EntityGetFirstComponent(entity_item, "OrbComponent")
+		if orb_comp then
+			EntityRemoveComponent(entity_item, orb_comp)
 		end
 	end
 

--- a/init.lua
+++ b/init.lua
@@ -320,7 +320,7 @@ function RECV_MSG.Connected()
 
 	for _, location in ipairs(ap.missing_locations) do
 		missing_locations_set[location] = true
-		print("location is " .. location)
+		-- print("location is " .. location)
 		if peds_list[location] == true then
 			peds_checklist[location] = true
 		end


### PR DESCRIPTION
The issue was that if there were more orbs on the ground than you need to achieve your goal, the existing orbs would still have valid OrbComponents, and so would still increment your orb counter. Now, they get removed when you pick them up, stopping the counter from incrementing.