### PR TITLE
Death link fix

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -70,6 +70,9 @@ end
 
 
 local function IsDeathLinkEnabled()
+	if slot_options == nil then
+		slot_options.death_link = 0
+	end
 	return slot_options.death_link == 1 and ModSettingGet("archipelago.death_link")
 end
 

--- a/init.lua
+++ b/init.lua
@@ -71,7 +71,7 @@ end
 
 local function IsDeathLinkEnabled()
 	if slot_options == nil then
-		slot_options.death_link = 0
+		return false
 	end
 	return slot_options.death_link == 1 and ModSettingGet("archipelago.death_link")
 end


### PR DESCRIPTION
```
LUA: 17:38:29 [AP] No connection could be made because the target machine actively refused it.    
Lua error - [string "mods/archipelago/init.lua"]:73: attempt to index upvalue 'slot_options' (a nil value)
  Stack traceback:
      [string "mods/archipelago/init.lua"]:73: in function 'IsDeathLinkEnabled'
      [string "mods/archipelago/init.lua"]:574: in function <[string "mods/archipelago/init.lua"]:570>
```

Attempting to fix this with this PR.

When the player connected to their slot, it immediately disconnected them. I'm going to assume OnPauseChanged can happen at the main menu somewhere? Will test this tonight, just writing it up in browser on my work computer for now.