### PR TITLE
Implement progressive HM portals

### DIFF
--- a/data/archipelago/entities/buildings/ap_closed_portal.xml
+++ b/data/archipelago/entities/buildings/ap_closed_portal.xml
@@ -1,0 +1,80 @@
+<Entity>
+	<UIInfoComponent
+		_tags="locked_by_archipelago"
+		name="$ap_closed_portal"
+	/>
+
+	<LightComponent
+		_tags="locked_by_archipelago"
+		_enabled="1"
+		radius="128"
+		fade_out_time="1.5"
+		r="50"
+		g="80"
+		b="200"
+		offset_y="-16"
+	/>
+
+	<ParticleEmitterComponent
+		_tags="locked_by_archipelago"
+		emitted_material_name="spark_purple"
+		gravity.y="0.0"
+		lifetime_min="2"
+		lifetime_max="3"
+		x_vel_min="0"
+		x_vel_max="0"
+		y_vel_min="0"
+		y_vel_max="0"
+		count_min="8"
+		count_max="10"
+		render_on_grid="1"
+		fade_based_on_lifetime="0"
+		area_circle_radius.min="3"
+		area_circle_radius.max="6"
+		cosmetic_force_create="1"
+		collide_with_grid="0"
+		airflow_force="0.02"
+		airflow_time="0.4"
+		airflow_scale="0.02"
+		emission_interval_min_frames="4"
+		emission_interval_max_frames="5"
+		emit_cosmetic_particles="1"
+		velocity_always_away_from_center="4"
+		render_back="1"
+		is_emitting="1"
+	/>
+
+	<AudioLoopComponent
+		_tags="locked_by_archipelago"
+		file="data/audio/Desktop/misc.bank"
+		event_name="misc/teleport_loop"
+		calculate_material_lowpass="0"
+		auto_play="0"
+		auto_play_if_enabled="1"
+		play_on_component_enable="1"
+	/>
+
+	<SpriteComponent
+		_tags="locked_by_archipelago"
+		image_file="data/fonts/font_pixel_white.xml"
+		is_text_sprite="1"
+		alpha="0"
+		offset_x="0"
+		offset_y="0"
+		update_transform="1"
+		update_transform_rotation="0"
+		text="..."
+		z_index="-1"
+		has_special_scale="1"
+		special_scale_x="0.5"
+		special_scale_y="0.5"
+	 />
+
+	<LuaComponent
+		script_source_file="data/archipelago/entities/buildings/ap_closed_portal_text_update.lua"
+		execute_every_n_frame="3"
+		call_init_function="1"
+		execute_on_added="1"
+	/>
+
+</Entity>

--- a/data/archipelago/entities/buildings/ap_closed_portal_text_update.lua
+++ b/data/archipelago/entities/buildings/ap_closed_portal_text_update.lua
@@ -1,0 +1,39 @@
+local FADE_DISTANCE = 80 * 80
+local entity_id = GetUpdatedEntityID()
+
+
+local function dist2(x1, y1, x2, y2)
+	local dx = x2 - x1
+	local dy = y2 - y1
+	return dx * dx + dy * dy
+end
+
+function init(entity_id)
+	local text_desc = GameTextGetTranslatedOrNot("$ap_closed_portal_desc")
+
+	local gui = GuiCreate()
+	local width = GuiGetTextDimensions(gui, text_desc, 0.5)
+	GuiDestroy(gui)
+
+	local text_component = EntityGetFirstComponentIncludingDisabled(entity_id, "SpriteComponent", "locked_by_archipelago")
+	assert(text_component)
+
+	ComponentSetValue2(text_component, "text", text_desc)
+	ComponentSetValue2(text_component, "offset_x", math.floor(width))
+end
+
+local function update()
+	local text_component = EntityGetFirstComponent(entity_id, "SpriteComponent", "locked_by_archipelago")
+	if not text_component then return end
+
+	local cam_x, cam_y = GameGetCameraPos()
+	local entity_x, entity_y = EntityGetTransform(entity_id)
+
+	local sq_dist = dist2(entity_x, entity_y, cam_x, cam_y)
+	local fade = math.min(sq_dist, FADE_DISTANCE) / FADE_DISTANCE
+
+	local alpha = ((1 - fade) * 0.75) ^ 3
+	ComponentSetValue2(text_component, "alpha", alpha)
+end
+
+update()

--- a/data/archipelago/scripts/apply_ap_patches.lua
+++ b/data/archipelago/scripts/apply_ap_patches.lua
@@ -42,3 +42,4 @@ ModLuaFileAppend("data/scripts/buildings/forge_item_convert.lua", "data/archipel
 
 -- ADDITIONAL SCRIPTS
 dofile_once("data/archipelago/scripts/patches/ap_extend_pixel_scenes.lua")
+dofile_once("data/archipelago/scripts/patches/ap_extend_portals.lua")

--- a/data/archipelago/scripts/constants.lua
+++ b/data/archipelago/scripts/constants.lua
@@ -49,4 +49,27 @@ return {
 	ITEM_FLAG_PROGRESSION = 1,
 	ITEM_FLAG_USEFUL = 2,
 	ITEM_FLAG_TRAP = 4,
+
+
+	-- Major update stuff
+
+	-- this is required 7 times or not at all per new slot option
+	PROGRESSIVE_PORTAL_ITEM_ID = 20000,
+
+	-- not sure how to do these yet
+	PROGRESSIVE_LEFT_PARALLEL_WORLD = 20001,
+	PROGRESSIVE_RIGHT_PARALLEL_WORLD = 20002,
+
+	-- Killsanity
+	-- TODO (185 enemies)
+
+	-- Spellsanity
+	SPELL_FIRST_ITEM_ID = 30000,
+	SPELL_LAST_ITEM_ID = 30421,
+
+	APOTHEOSIS_SPELL_FIRST_ITEM_ID = 31000,
+
+	-- Perksanity
+	UNLOCK_PERK_FIRST_ITEM_ID = 40000,
+	UNLOCK_PERK_LAST_ITEM_ID = 40105,
 }

--- a/data/archipelago/scripts/globals.lua
+++ b/data/archipelago/scripts/globals.lua
@@ -6,6 +6,7 @@ return {
 	Seed = Global("ARCHIPELAGO_SEED"),
 	FirstLoadDone = Global("ARCHIPELAGO_FIRST_LOAD_DONE"),
 	PlayerSlot = Global("ARCHIPELAGO_PLAYER_SLOT"),
+	HMPortalsUnlocked = Global("ARCHIPELAGO_PORTALS_UNLOCKED"),
 
 	LocationScouts = GlobalComplex("AP_LOCATIONSCOUTS_DATA"),
 	MissingLocationsSet = GlobalComplex("AP_MISSING_LOCATIONS"),

--- a/data/archipelago/scripts/item_mappings.lua
+++ b/data/archipelago/scripts/item_mappings.lua
@@ -2,6 +2,8 @@
 -- redeliverable means it will be delivered in async
 -- newgame means it will be delivered on new game
 return {
+	[20000] = { redeliverable = true, newgame = true }, -- progressive portal
+
 	[110000] = {},	-- Trap
 
 	[110001] = { items = { "data/entities/items/pickup/heart.xml" }, redeliverable = true, newgame = true },

--- a/data/archipelago/scripts/item_utils.lua
+++ b/data/archipelago/scripts/item_utils.lua
@@ -3,6 +3,7 @@ dofile_once("data/archipelago/scripts/newgame_spawner.lua")
 
 local item_table = dofile("data/archipelago/scripts/item_mappings.lua")
 local AP = dofile("data/archipelago/scripts/constants.lua")
+local Globals = dofile("data/archipelago/scripts/globals.lua")
 local Log = dofile("data/archipelago/scripts/logger.lua")
 
 -- Traps
@@ -55,6 +56,9 @@ function SpawnItem(item_id, traps)
 		BadTimes()
 		GlobalsSetValue("ap_random_hax", tostring(rand_x + 2))
 		Log.Info("Badtimes")
+	elseif item_id == AP.PROGRESSIVE_PORTAL_ITEM_ID then
+		Globals.HMPortalsUnlocked:set(Globals.HMPortalsUnlocked:get_num(0) + 1)
+		Log.Info("Progressive portal received")
 	elseif item.perk ~= nil then
 		give_perk(item.perk)
 		Log.Info("Perk spawned")

--- a/data/archipelago/scripts/patches/ap_extend_portals.lua
+++ b/data/archipelago/scripts/patches/ap_extend_portals.lua
@@ -1,0 +1,31 @@
+
+---@type nxml
+local nxml = dofile_once("data/archipelago/lib/nxml.lua")
+
+local closed_portal_xml = nxml.parse_file("data/archipelago/entities/buildings/ap_closed_portal.xml")
+
+local function update_portal_xml(xml)
+	-- Disable portals by default and have them enabled through code
+	for comp in xml:each_child() do
+		local tag = comp:get("_tags") or ""
+		if tag:find("enabled_by_liquid", 1, true) then
+			comp:set("_enabled", 0)
+		end
+	end
+
+	xml:add_children(closed_portal_xml.children)
+end
+
+for xml in nxml.edit_file("data/entities/buildings/teleport_liquid_powered.xml") do
+	update_portal_xml(xml)
+end
+
+for xml in nxml.edit_file("data/entities/buildings/teleport_ending.xml") do
+	update_portal_xml(xml)
+
+	for comp in xml:each_of("ParticleEmitterComponent") do
+		comp:set("emitted_material_name", "spark_red")
+	end
+end
+
+ModLuaFileAppend("data/scripts/buildings/teleport_liquid_check.lua", "data/archipelago/scripts/patches/ap_extend_portals_liquid_check.lua")

--- a/data/archipelago/scripts/patches/ap_extend_portals_liquid_check.lua
+++ b/data/archipelago/scripts/patches/ap_extend_portals_liquid_check.lua
@@ -1,0 +1,50 @@
+local ap_original_material_area_checker_failed = material_area_checker_failed
+local ap_original_material_area_checker_success = material_area_checker_success
+
+local Globals = dofile_once("data/archipelago/scripts/globals.lua")
+
+local function get_hm_portal_num(y)
+	if y < 1500 then return 1 -- Mines
+	elseif y < 3000 then return 2 -- Coal Pits
+	elseif y < 5500 then return 3 -- Snowy Depths
+	elseif y < 7000 then return 4 -- Hiisi Base
+	elseif y < 9500 then return 5 -- Underground Jungle
+	elseif y < 11500 then return 6 -- The Vault
+	else return 7 -- Temple of the Art
+	end
+end
+
+-- true if unlocked, false if locked
+local function archipelago_test_portal()
+	local entity_id = GetUpdatedEntityID()
+
+	if GameHasFlagRun("ap_portals_locked") then
+		local _, y = EntityGetTransform(entity_id)
+		local currentHM = get_hm_portal_num(y)
+		local totalHM = Globals.HMPortalsUnlocked:get_num(0)
+		if currentHM > totalHM then
+			-- Portal locked
+			EntitySetComponentsWithTagEnabled(entity_id, "enabled_by_liquid", false)
+			EntitySetComponentsWithTagEnabled(entity_id, "locked_by_archipelago", true)
+			return false
+		end
+	end
+
+	-- Disable locking mechanism
+	EntitySetComponentsWithTagEnabled(entity_id, "locked_by_archipelago", false)
+	return true
+end
+
+function material_area_checker_failed(pos_x, pos_y)
+	local entity_id = GetUpdatedEntityID()
+
+	-- Portal loses teleportatium, should vanish completely
+	EntitySetComponentsWithTagEnabled(entity_id, "locked_by_archipelago", false)
+	ap_original_material_area_checker_failed(pos_x, pos_y)
+end
+
+function material_area_checker_success(pos_x, pos_y)
+	if GameHasFlagRun("ap_connected_once") and archipelago_test_portal() then
+		ap_original_material_area_checker_success(pos_x, pos_y)
+	end
+end

--- a/data/archipelago/translations.csv
+++ b/data/archipelago/translations.csv
@@ -48,3 +48,5 @@
 "perkdesc_ap_leggy_feet","You grow disturbing looking, colourful limbs that fight for you.",,,,,,,,,,,,,
 "ap_portal_from_egg","Portal to the Mountain entrance",,,,,,,,,,,,,
 "ap_portal_to_egg","Portal to the Archipelago egg",,,,,,,,,,,,,
+"ap_closed_portal","Locked portal",,,,,,,,,,,,,
+"ap_closed_portal_desc","Requires: Progressive Holy Mountain Portal",,,,,,,,,,,,,

--- a/init.lua
+++ b/init.lua
@@ -308,6 +308,8 @@ function RECV_MSG.Connected()
 	GamePrint("$ap_connected_to_server")
 	ConnIcon:setConnected()
 
+	GameAddFlagRun("ap_connected_once")
+
 	-- need these elsewhere
 	if slot_options.victory_condition == 1 then
 		GameAddFlagRun("ap_pure_goal")
@@ -320,6 +322,9 @@ function RECV_MSG.Connected()
 	end
 	if slot_options.path_option == 4 then
 		GameAddFlagRun("ap_parallel_worlds")
+	end
+	if slot_options.lock_portals ~= nil then
+		GameAddFlagRun("ap_portals_locked")
 	end
 
 	current_player_slot = ap:get_player_number()
@@ -370,11 +375,15 @@ function RECV_MSG.ReceivedItems(items)
 			local item_id = item["item"]
 			-- when connected for the first time, you get receiveditems along with connected
 			-- but also, you want to give the player gold and stuff that got sent before spawning
-			if is_first_time_connected and not item_table[item_id].newgame and item_table[item_id].redeliverable then
+			if not item_table[item_id] then
+				Log.Error("[AP] spawn_item: Item id " .. tostring(item_id) .. " does not exist!")
+			elseif is_first_time_connected and not item_table[item_id].newgame and item_table[item_id].redeliverable then
 				SpawnReceivedItem(item)
 			elseif not is_first_time_connected or GameHasFlagRun("ap_spawn_kill_saver") then
 				SpawnReceivedItem(item)
 			end
+
+
 		end
 	end
 


### PR DESCRIPTION
|<img width="802" height="467" alt="2025-12-06 02_43_08-Noita - Build Jan 25 2025 - 15_55_41" src="https://github.com/user-attachments/assets/e4bdfaba-b66c-42fb-afed-77866f272f4c" />|<img width="855" height="557" alt="2025-12-06 02_43_19-Noita - Build Jan 25 2025 - 15_55_41" src="https://github.com/user-attachments/assets/f966d713-bbdc-4132-8324-f5ad0ea874b5" />|
|--|--|

- There is a red version for red boss portals.
- Backwards compatible.
- Needs AP to send the slot option "lock_portals" (any value) to enable.
- Needs AP to place 7 "Progressive Holy Mountain" (item id 20000) into the pool.